### PR TITLE
Fix upcoming walk card data handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,14 +55,14 @@
                         <div id="upcoming-walk-section">
                             <h2 class="text-lg font-semibold mb-3">Upcoming Walk</h2>
                             <div id="upcoming-walk-card" class="glass-card p-4 flex items-center gap-4 cursor-pointer" data-walk-id="99">
-                                <img src="https://placehold.co/100x100/7F00FF/FFFFFF?text=J" alt="Jordan Lee" class="w-12 h-12 rounded-full">
+                                <img id="upcoming-walk-avatar" src="https://placehold.co/100x100/7F00FF/FFFFFF?text=J" alt="Jordan Lee" class="w-12 h-12 rounded-full">
                                 <div>
-                                    <p class="font-semibold">With Jordan Lee</p>
-                                    <p class="text-sm opacity-80">Today at 4:00 PM</p>
+                                    <p class="font-semibold" id="upcoming-walk-title">With Jordan Lee</p>
+                                    <p class="text-sm opacity-80" id="upcoming-walk-time">Today at 4:00 PM</p>
                                 </div>
                                 <div class="ml-auto text-right">
-                                    <p class="font-bold">30 min</p>
-                                    <p class="text-sm opacity-80">🐶 Buddy</p>
+                                    <p class="font-bold" id="upcoming-walk-duration">30 min</p>
+                                    <p class="text-sm opacity-80" id="upcoming-walk-dogs">🐶 Buddy</p>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- render the dashboard upcoming walk card with the latest in-progress or upcoming walk details
- capture service duration and time for newly booked walks so they surface on the dashboard
- add dedicated DOM hooks for updating the upcoming walk card fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d58dbde278832f8b23f47fd2d9e90a