### PR TITLE
Add primary booking action to bottom nav

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -189,17 +189,67 @@ body::after {
     border-radius: 99px;
     border: 1px solid rgba(255,255,255,0.1);
     display: flex;
-    justify-content: space-around;
-    padding: 0.75rem 0.5rem;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.75rem 0.75rem;
     box-shadow: var(--shadow-strong);
     z-index: 50;
 }
 .nav-item {
-    background: none; border: none; color: rgba(255,255,255,0.6); display: flex; flex-direction: column;
-    align-items: center; font-size: 0.7rem; gap: 0.2rem; padding: 0 0.5rem; transition: all 0.3s ease;
+    background: none;
+    border: none;
+    color: rgba(255,255,255,0.6);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    gap: 0.2rem;
+    padding: 0 0.5rem;
+    transition: all 0.3s ease;
+    flex: 1;
+    border-radius: 0.75rem;
+    cursor: pointer;
 }
+.nav-item-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.nav-item svg { color: currentColor; }
 .nav-item.active { color: white; }
 .nav-item.active svg { color: var(--primary-color-light); }
+.nav-item-primary.active svg { color: currentColor; }
+
+.nav-item-primary {
+    background: var(--primary-color);
+    color: #fff;
+    flex: 0 0 auto;
+    flex-direction: row;
+    gap: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    box-shadow: 0 12px 32px rgba(138, 43, 226, 0.45);
+}
+.nav-item-primary svg {
+    width: 22px;
+    height: 22px;
+    color: inherit;
+}
+.nav-item-primary:hover,
+.nav-item-primary:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 36px rgba(147, 112, 219, 0.5);
+}
+.nav-item-primary:focus-visible {
+    outline: 2px solid rgba(255,255,255,0.6);
+    outline-offset: 2px;
+}
+.nav-item-primary:active {
+    transform: translateY(0);
+}
 
 /* Staggered Animation */
 .stagger-in > * {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -139,6 +139,20 @@ const goToPage = (pageId, context = null) => {
     }
 };
 
+function launchBookingFlow(source = 'nav') {
+    const bookingPage = document.getElementById('page-booking-flow');
+    if (!bookingPage) return;
+
+    bookingPage.innerHTML = fullBookingFlowHTML;
+    fullInitBookingFlow();
+
+    if (typeof window !== 'undefined' && window.analytics && typeof window.analytics.track === 'function') {
+        window.analytics.track('navigate_to_booking_flow', { source });
+    }
+
+    goToPage('page-booking-flow');
+}
+
 function vibrate(duration = 10) { if (window.navigator.vibrate) window.navigator.vibrate(duration); }
 
 function renderDashboard() {
@@ -561,7 +575,18 @@ function initApp() {
 }
 
 // Add main event listeners
-document.querySelectorAll('.nav-item').forEach(item => item.addEventListener('click', () => goToPage(item.dataset.target)));
+function handleNavItemClick(item) {
+    const target = item?.dataset?.target;
+    if (!target) return;
+
+    if (target === 'page-booking-flow') {
+        launchBookingFlow('bottom-nav');
+    } else {
+        goToPage(target);
+    }
+}
+
+document.querySelectorAll('.nav-item').forEach(item => item.addEventListener('click', () => handleNavItemClick(item)));
 document.body.addEventListener('click', e => {
      const backBtn = e.target.closest('.back-btn');
      const profileLink = e.target.closest('.profile-link');
@@ -572,11 +597,7 @@ document.body.addEventListener('click', e => {
          goToPage(profileLink.dataset.target);
      }
 });
-document.getElementById('cta-book-walk').addEventListener('click', () => {
-    document.getElementById('page-booking-flow').innerHTML = fullBookingFlowHTML;
-    fullInitBookingFlow();
-    goToPage('page-booking-flow');
-});
+document.getElementById('cta-book-walk').addEventListener('click', () => launchBookingFlow('home-cta'));
 document.getElementById('cta-recurring-walk').addEventListener('click', () => goToPage('page-recurring-walks'));
 document.getElementById('btn-add-dog').addEventListener('click', () => goToPage('page-dog-form'));
 

--- a/index.html
+++ b/index.html
@@ -173,6 +173,20 @@
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><line x1="10" y1="9" x2="8" y2="9"/></svg>
                 <span>History</span>
             </button>
+            <button class="nav-item nav-item-primary" data-target="page-booking-flow" aria-label="Book a walk">
+                <span class="nav-item-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="15.5" r="3.5"></circle>
+                        <circle cx="17.5" cy="9" r="1.8"></circle>
+                        <circle cx="6.5" cy="9" r="1.8"></circle>
+                        <circle cx="5" cy="15.5" r="1.5"></circle>
+                        <circle cx="19" cy="15.5" r="1.5"></circle>
+                        <line x1="12" y1="4" x2="12" y2="8"></line>
+                        <line x1="10" y1="6" x2="14" y2="6"></line>
+                    </svg>
+                </span>
+                <span>Book Walk</span>
+            </button>
              <button class="nav-item" data-target="page-inbox">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 22v-7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v7"/><path d="M4 18h.01"/><path d="M2 14h.01"/><path d="M22 14h-.01"/><path d="M18 18h.01"/><path d="M6 18h.01"/><path d="M12 18h.01"/><path d="M16 5.86a4.5 4.5 0 1 0-8 0c0 1.5.63 3.05 1.76 4.14L12 12l2.24-2c1.13-1.09 1.76-2.64 1.76-4.14Z"/></svg>
                 <span>Messages</span>


### PR DESCRIPTION
## Summary
- add a prominent “Book Walk” action to the bottom navigation targeting the booking flow
- style the primary nav item with accent colors and a larger tap target to highlight the main action
- route the new nav entry point through the existing booking flow initialization, with optional analytics support

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d59dec1c18832f8ae7a9d967044b75