### PR TITLE
Streamline navigation and add profile access sheet

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -172,7 +172,44 @@ body::after {
     margin-right: auto;
 }
 .page-header .placeholder { /* To balance the back button */
-     width: 40px; 
+     width: 40px;
+}
+
+.home-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding-top: 1rem;
+}
+
+.home-header-info {
+    display: flex;
+    flex-direction: column;
+    text-align: left;
+    gap: 0.25rem;
+}
+
+.profile-trigger {
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid var(--glass-border);
+    border-radius: 999px;
+    padding: 0.3rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+}
+
+.profile-trigger:hover,
+.profile-trigger:focus-visible {
+    border-color: var(--primary-color-light);
+    box-shadow: 0 0 0 3px rgba(147, 112, 219, 0.35);
+    outline: none;
+}
+
+.profile-trigger img {
+    pointer-events: none;
 }
 
 /* Bottom Navigation */
@@ -200,6 +237,122 @@ body::after {
 }
 .nav-item.active { color: white; }
 .nav-item.active svg { color: var(--primary-color-light); }
+
+.profile-sheet-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.65);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+    z-index: 80;
+    pointer-events: none;
+}
+
+.profile-sheet-overlay.active {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+
+.profile-sheet {
+    position: fixed;
+    left: 50%;
+    bottom: 0;
+    transform: translate(-50%, 110%);
+    width: 100%;
+    max-width: 420px;
+    background: rgba(25, 10, 45, 0.9);
+    border: 1px solid var(--glass-border);
+    border-bottom: none;
+    border-radius: 1.5rem 1.5rem 0 0;
+    box-shadow: 0 -20px 45px rgba(17, 7, 30, 0.5);
+    padding: 1.75rem 1.5rem 2rem;
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    transition: transform 0.35s ease, opacity 0.35s ease;
+    opacity: 0;
+    pointer-events: none;
+    z-index: 90;
+}
+
+.profile-sheet.active {
+    transform: translate(-50%, 0);
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.profile-sheet-handle {
+    width: 42px;
+    height: 5px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.25);
+    margin: 0 auto 1.25rem auto;
+}
+
+.profile-sheet-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.profile-sheet-close {
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid var(--glass-border);
+    border-radius: 999px;
+    padding: 0.35rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-color);
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.profile-sheet-close:hover,
+.profile-sheet-close:focus-visible {
+    border-color: var(--primary-color-light);
+    box-shadow: 0 0 0 3px rgba(147, 112, 219, 0.35);
+    outline: none;
+}
+
+.profile-sheet-content {
+    margin-top: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.profile-sheet-link {
+    width: 100%;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: 1rem;
+    padding: 1rem 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    text-align: left;
+    color: inherit;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.profile-sheet-link:hover,
+.profile-sheet-link:focus-visible {
+    border-color: var(--primary-color-light);
+    box-shadow: 0 12px 30px rgba(147, 112, 219, 0.25);
+    transform: translateY(-2px);
+    outline: none;
+}
+
+.profile-sheet-footer {
+    margin-top: 2rem;
+}
 
 /* Staggered Animation */
 .stagger-in > * {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -32,6 +32,24 @@ const paymentData = {
 // --- APP STATE ---
 const appState = { currentPage: 'page-home' };
 
+const toggleProfileSheet = (show = false) => {
+    const sheet = document.getElementById('profile-sheet');
+    const overlay = document.getElementById('profile-sheet-overlay');
+    if (!sheet || !overlay) return;
+
+    if (show) {
+        sheet.classList.add('active');
+        overlay.classList.add('active');
+        sheet.setAttribute('aria-hidden', 'false');
+    } else {
+        sheet.classList.remove('active');
+        overlay.classList.remove('active');
+        sheet.setAttribute('aria-hidden', 'true');
+    }
+};
+
+const closeProfileSheet = () => toggleProfileSheet(false);
+
 // --- BOOKING FLOW HTML ---
 const fullBookingFlowHTML = `
     <div class="page-header"><button class="back-btn" data-target="page-home"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg></button><h1>Book a Walk</h1></div>
@@ -103,6 +121,8 @@ const goToPage = (pageId, context = null) => {
     const navItems = document.querySelectorAll('.nav-item');
     const mainContent = document.querySelector('.main-content');
     const appContainer = document.querySelector('.app-container');
+
+    closeProfileSheet();
 
     pages.forEach(page => page.classList.remove('active'));
     const targetPage = document.getElementById(pageId);
@@ -562,6 +582,34 @@ function initApp() {
 
 // Add main event listeners
 document.querySelectorAll('.nav-item').forEach(item => item.addEventListener('click', () => goToPage(item.dataset.target)));
+
+const profileOverlay = document.getElementById('profile-sheet-overlay');
+const profileCloseBtn = document.getElementById('profile-sheet-close');
+const profileTriggerBtn = document.getElementById('home-profile-button');
+
+if (profileTriggerBtn) profileTriggerBtn.addEventListener('click', () => toggleProfileSheet(true));
+if (profileCloseBtn) profileCloseBtn.addEventListener('click', closeProfileSheet);
+if (profileOverlay) profileOverlay.addEventListener('click', closeProfileSheet);
+
+document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') {
+        const sheet = document.getElementById('profile-sheet');
+        if (sheet && sheet.classList.contains('active')) {
+            closeProfileSheet();
+        }
+    }
+});
+
+document.querySelectorAll('.profile-sheet-link').forEach(link => {
+    link.addEventListener('click', e => {
+        const target = link.dataset.target;
+        if (!target) return;
+        e.preventDefault();
+        closeProfileSheet();
+        goToPage(target);
+    });
+});
+
 document.body.addEventListener('click', e => {
      const backBtn = e.target.closest('.back-btn');
      const profileLink = e.target.closest('.profile-link');

--- a/index.html
+++ b/index.html
@@ -47,9 +47,14 @@
                 <!-- ===== PAGE: HOME/DASHBOARD ===== -->
                 <section class="page" id="page-home">
                     <div class="space-y-8 stagger-in">
-                        <div class="text-center pt-4">
-                            <h1 class="text-3xl font-bold">Hello, Alex!</h1>
-                            <p class="opacity-80">Ready for a new adventure? 🐾</p>
+                        <div class="home-header">
+                            <div class="home-header-info">
+                                <h1 class="text-3xl font-bold">Hello, Alex!</h1>
+                                <p class="opacity-80">Ready for a new adventure? 🐾</p>
+                            </div>
+                            <button id="home-profile-button" class="profile-trigger" aria-haspopup="dialog" aria-controls="profile-sheet" aria-label="Open profile and settings">
+                                <img src="https://placehold.co/100x100/9370DB/FFFFFF?text=A" alt="Alex Morgan" class="w-12 h-12 rounded-full border-2 border-[var(--glass-border)]">
+                            </button>
                         </div>
                         
                         <div id="upcoming-walk-section">
@@ -177,15 +182,47 @@
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 22v-7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v7"/><path d="M4 18h.01"/><path d="M2 14h.01"/><path d="M22 14h-.01"/><path d="M18 18h.01"/><path d="M6 18h.01"/><path d="M12 18h.01"/><path d="M16 5.86a4.5 4.5 0 1 0-8 0c0 1.5.63 3.05 1.76 4.14L12 12l2.24-2c1.13-1.09 1.76-2.64 1.76-4.14Z"/></svg>
                 <span>Messages</span>
             </button>
-            <button class="nav-item" data-target="page-dogs">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.66 22.47a2.5 2.5 0 0 0 2.68 0l.28-.11a1.23 1.23 0 0 1 1.2 0l.35.14a2.5 2.5 0 0 0 2.52 0l.28-.11a1.23 1.23 0 0 1 1.2 0l.35.14a2.5 2.5 0 0 0 2.52 0l.28-.11a1.23 1.23 0 0 1 1.2 0l.35.14a2.5 2.5 0 0 0 2.52 0V8.29a2.5 2.5 0 0 0-1.26-2.17l-.35-.18a1.23 1.23 0 0 1-.6-1.08V4.5a2.5 2.5 0 0 0-2.5-2.5h-2.5"/><path d="M2.12 12.21a2.5 2.5 0 0 0-1.26 2.17v.3a2.5 2.5 0 0 0 2.5 2.5h.5a1.23 1.23 0 0 1 1.2 1.2v.3a2.5 2.5 0 0 0 2.5 2.5h.5a1.23 1.23 0 0 1 1.2 1.2v.3a2.5 2.5 0 0 0 2.5 2.5h.5"/></svg>
-                <span>Dogs</span>
-            </button>
-            <button class="nav-item" data-target="page-profile">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
-                <span>Profile</span>
-            </button>
         </nav>
+        <div id="profile-sheet-overlay" class="profile-sheet-overlay"></div>
+        <aside id="profile-sheet" class="profile-sheet" aria-labelledby="profile-sheet-title" aria-hidden="true" role="dialog">
+            <div class="profile-sheet-handle" aria-hidden="true"></div>
+            <div class="profile-sheet-header">
+                <div>
+                    <p class="text-sm uppercase tracking-wide opacity-70">Account</p>
+                    <h2 id="profile-sheet-title" class="text-2xl font-bold">Alex Morgan</h2>
+                    <p class="opacity-70 text-sm">Manage your profile and pups</p>
+                </div>
+                <button id="profile-sheet-close" class="profile-sheet-close" aria-label="Close profile menu">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+                </button>
+            </div>
+            <div class="profile-sheet-content">
+                <button class="profile-sheet-link" data-target="page-profile">
+                    <div>
+                        <p class="font-semibold">Profile & Settings</p>
+                        <p class="text-sm opacity-70">Update contact info, payments, and preferences</p>
+                    </div>
+                    <span aria-hidden="true">›</span>
+                </button>
+                <button class="profile-sheet-link" data-target="page-dogs">
+                    <div>
+                        <p class="font-semibold">Manage My Dogs</p>
+                        <p class="text-sm opacity-70">Edit profiles and add new furry friends</p>
+                    </div>
+                    <span aria-hidden="true">›</span>
+                </button>
+                <button class="profile-sheet-link" data-target="page-recurring-walks">
+                    <div>
+                        <p class="font-semibold">Scheduled Walks</p>
+                        <p class="text-sm opacity-70">Review or adjust recurring plans</p>
+                    </div>
+                    <span aria-hidden="true">›</span>
+                </button>
+            </div>
+            <div class="profile-sheet-footer">
+                <button class="btn btn-secondary w-full">Log Out</button>
+            </div>
+        </aside>
     </div>
 
     <!-- Success Modal will be appended to body by JS to ensure it's on top -->


### PR DESCRIPTION
## Summary
- streamline the bottom navigation to focus on core pages and introduce a profile trigger in the home header
- add a profile access sheet that surfaces profile, dog management, and scheduled walk links outside the main nav
- update styling and scripts to support the new sheet interactions and ensure routing closes the sheet cleanly

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d59dee7978832fb5e278d9f623f61b