### PR TITLE
Remove historical walks from home dashboard

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -247,34 +247,6 @@ function renderDashboard() {
             </div>`).join('');
     }
 
-    const historyList = document.getElementById('home-history-list');
-    if (historyList) {
-        historyList.innerHTML = completedWalks.map(walk => `
-            <div class="glass-card p-4 cursor-pointer home-history-item" data-walk-id="${walk.id}">
-                <div class="flex justify-between items-center">
-                    <div>
-                        <p class="font-bold text-lg">${new Date(walk.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}</p>
-                        <p class="text-sm opacity-80">With ${walk.walker.name}</p>
-                    </div>
-                    <div class="text-right">
-                        <p class="font-bold text-lg">$${walk.price.toFixed(2)}</p>
-                        <p class="text-sm opacity-80">${walk.dogs.map(d => d.avatar).join(' ')}</p>
-                    </div>
-                </div>
-            </div>`).join('');
-
-        historyList.querySelectorAll('.home-history-item').forEach(item => {
-            item.addEventListener('click', e => {
-                const walkId = parseInt(e.currentTarget.dataset.walkId);
-                goToPage('page-walk-summary', { walkId });
-            });
-        });
-    }
-
-    const viewAllHistoryBtn = document.getElementById('btn-view-all-history');
-    if (viewAllHistoryBtn) {
-        viewAllHistoryBtn.onclick = () => goToPage('page-history');
-    }
 }
 
 function renderHistoryPage() {

--- a/index.html
+++ b/index.html
@@ -77,13 +77,7 @@
                              <div class="space-y-3" id="recent-activity-list"></div>
                         </div>
 
-                        <div>
-                             <div class="flex items-center justify-between mb-3">
-                                 <h2 class="text-lg font-semibold">Historical Walks</h2>
-                                 <button id="btn-view-all-history" class="btn btn-secondary text-sm py-2 px-4">View all</button>
-                             </div>
-                             <div class="space-y-3" id="home-history-list"></div>
-                        </div>
+                        
                     </div>
                 </section>
                 


### PR DESCRIPTION
## Summary
- remove the Historical Walks panel from the home dashboard markup
- simplify dashboard rendering logic by dropping home-history list generation and the associated View All button hook

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5aec9bffc832fb33d8eb0b95805eb