### PR TITLE
Reorder bottom nav items

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,10 @@
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
                 <span>Home</span>
             </button>
+            <button class="nav-item" data-target="page-inbox">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 22v-7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v7"/><path d="M4 18h.01"/><path d="M2 14h.01"/><path d="M22 14h-.01"/><path d="M18 18h.01"/><path d="M6 18h.01"/><path d="M12 18h.01"/><path d="M16 5.86a4.5 4.5 0 1 0-8 0c0 1.5.63 3.05 1.76 4.14L12 12l2.24-2c1.13-1.09 1.76-2.64 1.76-4.14Z"/></svg>
+                <span>Messages</span>
+            </button>
             <button class="nav-item nav-item-primary" data-target="page-booking-flow" aria-label="Book a walk">
                 <span class="nav-item-icon">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -184,10 +188,6 @@
                     </svg>
                 </span>
                 <span>Book Walk</span>
-            </button>
-             <button class="nav-item" data-target="page-inbox">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 22v-7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v7"/><path d="M4 18h.01"/><path d="M2 14h.01"/><path d="M22 14h-.01"/><path d="M18 18h.01"/><path d="M6 18h.01"/><path d="M12 18h.01"/><path d="M16 5.86a4.5 4.5 0 1 0-8 0c0 1.5.63 3.05 1.76 4.14L12 12l2.24-2c1.13-1.09 1.76-2.64 1.76-4.14Z"/></svg>
-                <span>Messages</span>
             </button>
             <button class="nav-item" data-target="page-dogs">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.66 22.47a2.5 2.5 0 0 0 2.68 0l.28-.11a1.23 1.23 0 0 1 1.2 0l.35.14a2.5 2.5 0 0 0 2.52 0l.28-.11a1.23 1.23 0 0 1 1.2 0l.35.14a2.5 2.5 0 0 0 2.52 0l.28-.11a1.23 1.23 0 0 1 1.2 0l.35.14a2.5 2.5 0 0 0 2.52 0V8.29a2.5 2.5 0 0 0-1.26-2.17l-.35-.18a1.23 1.23 0 0 1-.6-1.08V4.5a2.5 2.5 0 0 0-2.5-2.5h-2.5"/><path d="M2.12 12.21a2.5 2.5 0 0 0-1.26 2.17v.3a2.5 2.5 0 0 0 2.5 2.5h.5a1.23 1.23 0 0 1 1.2 1.2v.3a2.5 2.5 0 0 0 2.5 2.5h.5a1.23 1.23 0 0 1 1.2 1.2v.3a2.5 2.5 0 0 0 2.5 2.5h.5"/></svg>


### PR DESCRIPTION
## Summary
- move the Messages tab before Book Walk in the bottom navigation
- keep the primary Book Walk button centered between two tabs on each side

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5b0550920832fa7c50cbb926c2dc1