### PR TITLE
Refresh bottom nav icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,9 @@
                 <span>Home</span>
             </button>
             <button class="nav-item" data-target="page-inbox">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 22v-7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v7"/><path d="M4 18h.01"/><path d="M2 14h.01"/><path d="M22 14h-.01"/><path d="M18 18h.01"/><path d="M6 18h.01"/><path d="M12 18h.01"/><path d="M16 5.86a4.5 4.5 0 1 0-8 0c0 1.5.63 3.05 1.76 4.14L12 12l2.24-2c1.13-1.09 1.76-2.64 1.76-4.14Z"/></svg>
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719" />
+                </svg>
                 <span>Messages</span>
             </button>
             <button class="nav-item nav-item-primary" data-target="page-booking-flow" aria-label="Book a walk">
@@ -190,7 +192,13 @@
                 <span>Book Walk</span>
             </button>
             <button class="nav-item" data-target="page-dogs">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.66 22.47a2.5 2.5 0 0 0 2.68 0l.28-.11a1.23 1.23 0 0 1 1.2 0l.35.14a2.5 2.5 0 0 0 2.52 0l.28-.11a1.23 1.23 0 0 1 1.2 0l.35.14a2.5 2.5 0 0 0 2.52 0l.28-.11a1.23 1.23 0 0 1 1.2 0l.35.14a2.5 2.5 0 0 0 2.52 0V8.29a2.5 2.5 0 0 0-1.26-2.17l-.35-.18a1.23 1.23 0 0 1-.6-1.08V4.5a2.5 2.5 0 0 0-2.5-2.5h-2.5"/><path d="M2.12 12.21a2.5 2.5 0 0 0-1.26 2.17v.3a2.5 2.5 0 0 0 2.5 2.5h.5a1.23 1.23 0 0 1 1.2 1.2v.3a2.5 2.5 0 0 0 2.5 2.5h.5a1.23 1.23 0 0 1 1.2 1.2v.3a2.5 2.5 0 0 0 2.5 2.5h.5"/></svg>
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M11.25 16.25h1.5L12 17z" />
+                    <path d="M16 14v.5" />
+                    <path d="M4.42 11.247A13.152 13.152 0 0 0 4 14.556C4 18.728 7.582 21 12 21s8-2.272 8-6.444a11.702 11.702 0 0 0-.493-3.309" />
+                    <path d="M8 14v.5" />
+                    <path d="M8.5 8.5c-.384 1.05-1.083 2.028-2.344 2.5-1.931.722-3.576-.297-3.656-1-.113-.994 1.177-6.53 4-7 1.923-.321 3.651.845 3.651 2.235A7.497 7.497 0 0 1 14 5.277c0-1.39 1.844-2.598 3.767-2.277 2.823.47 4.113 6.006 4 7-.08.703-1.725 1.722-3.656 1-1.261-.472-1.855-1.45-2.239-2.5" />
+                </svg>
                 <span>Dogs</span>
             </button>
             <button class="nav-item" data-target="page-profile">


### PR DESCRIPTION
## Summary
- replace the messages tab svg with a lucide message-circle glyph for a clearer chat metaphor
- swap the dogs tab icon for a lucide dog outline that complements the book walk paw graphic

## Testing
- Manual verification in browser


------
https://chatgpt.com/codex/tasks/task_e_68d5b46e8e34832f8fdbf5fcb40fd973