### PR TITLE
Add recurring walk scheduler management

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -135,6 +135,29 @@ body::after {
     color: var(--text-color);
     border: 1px solid var(--glass-border);
 }
+.btn-danger {
+    background: rgba(239, 68, 68, 0.12);
+    color: #fca5a5;
+    border: 1px solid rgba(239, 68, 68, 0.3);
+}
+.btn-danger:hover:not(:disabled) {
+    background: rgba(239, 68, 68, 0.2);
+    color: #fecaca;
+    box-shadow: 0 6px 18px rgba(239, 68, 68, 0.25);
+}
+.hidden { display: none !important; }
+.icon-button {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid var(--glass-border);
+    border-radius: 999px;
+    padding: 0.5rem;
+    color: var(--text-color);
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+.icon-button:hover {
+    background: rgba(255, 255, 255, 0.16);
+}
 .input-group {
     position: relative;
     background: var(--glass-bg);
@@ -273,6 +296,58 @@ body::after {
 #page-booking-flow .checkable-card input:checked + .card-content { border-color: var(--primary-color-light); box-shadow: 0 0 0 3px rgba(147, 112, 219, 0.4); }
 #page-booking-flow .checkmark { position: absolute; top: 0.75rem; right: 0.75rem; width: 24px; height: 24px; background: rgba(0,0,0,0.3); border-radius: 50%; display: flex; justify-content: center; align-items: center; opacity: 0; transform: scale(0.5); transition: all 0.3s ease; }
 #page-booking-flow .checkable-card input:checked ~ .checkmark { opacity: 1; transform: scale(1); background: var(--primary-color); }
+
+#page-recurring-walks .checkable-card { cursor: pointer; position: relative; text-align: center; }
+#page-recurring-walks .checkable-card input { display: none; }
+#page-recurring-walks .checkable-card .card-content { border: 1px solid var(--glass-border); border-radius: var(--border-radius); transition: all 0.3s ease; }
+#page-recurring-walks .checkable-card input:checked + .card-content { border-color: var(--primary-color-light); box-shadow: 0 0 0 3px rgba(147, 112, 219, 0.4); }
+#page-recurring-walks .checkmark { position: absolute; top: 0.5rem; right: 0.5rem; width: 22px; height: 22px; background: rgba(0,0,0,0.3); border-radius: 50%; display: flex; justify-content: center; align-items: center; opacity: 0; transform: scale(0.5); transition: all 0.3s ease; }
+#page-recurring-walks .checkable-card input:checked ~ .checkmark { opacity: 1; transform: scale(1); background: var(--primary-color); }
+
+#page-recurring-walks .walker-option { cursor: pointer; border: 1px solid var(--glass-border); transition: all 0.2s ease; position: relative; }
+#page-recurring-walks .walker-option input { display: none; }
+#page-recurring-walks .walker-option:hover { border-color: var(--primary-color-light); }
+#page-recurring-walks .walker-option .selection-indicator { opacity: 0; transition: opacity 0.2s ease; }
+#page-recurring-walks .walker-option.selected { border-color: var(--primary-color-light); box-shadow: 0 6px 16px rgba(147, 112, 219, 0.2); }
+#page-recurring-walks .walker-option.selected .selection-indicator { opacity: 1; }
+
+.scheduler-form { animation: fadeIn 0.25s ease; }
+.scheduler-form.active { display: block; }
+.day-picker-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0.5rem; }
+.day-toggle {
+    padding: 0.65rem 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid var(--glass-border);
+    background: rgba(255,255,255,0.05);
+    color: var(--text-color);
+    font-size: 0.875rem;
+    font-weight: 600;
+    transition: all 0.2s ease;
+}
+.day-toggle.active {
+    background: var(--primary-color);
+    border-color: var(--primary-color-light);
+    box-shadow: 0 6px 16px rgba(147, 112, 219, 0.35);
+}
+.day-toggle:focus-visible { outline: 2px solid var(--primary-color-light); outline-offset: 2px; }
+
+.status-badge {
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.3rem 0.75rem;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.status-badge--active { background: rgba(34, 197, 94, 0.18); color: #bbf7d0; border: 1px solid rgba(34, 197, 94, 0.35); }
+.status-badge--paused { background: rgba(234, 179, 8, 0.18); color: #fde68a; border: 1px solid rgba(234, 179, 8, 0.35); }
+
+.recurring-plan-card .btn { min-height: 44px; }
+.recurring-plan-card .next-occurrence { font-weight: 600; color: #c4b5fd; }
+
+@media (min-width: 480px) {
+    .day-picker-grid { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+}
 
 /* Chat Page Styles */
 #page-chat .chat-bubble { max-width: 75%; padding: 0.75rem 1rem; border-radius: 1.25rem; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -16,6 +16,23 @@ let walkHistoryData = [
     { id: 2, date: '2025-09-09', walker: walkerData[0], dogs: [dogData[0], dogData[1]], price: 40.00, status: 'Completed', photos: [], activity: { pee: true, poo: false, water: true }, note: "Lucy was a little shy but warmed up. Buddy was great as always." },
     { id: 3, date: '2025-09-05', walker: walkerData[2], dogs: [dogData[2]], price: 22.00, status: 'Completed', photos: ['https://placehold.co/300x200/9370DB/FFFFFF?text=Max+Running'], activity: { pee: true, poo: true, water: false }, note: "Max loved the long run by the lake!" },
 ];
+
+let recurringWalkPlans = [
+    {
+        id: 1,
+        label: 'Buddy Morning Crew',
+        dogIds: [1],
+        walkerId: 1,
+        daysOfWeek: [1, 3, 5],
+        time: '09:00',
+        duration: 30,
+        startDate: '2025-09-18',
+        address: '123 Bark Ave',
+        notes: 'Buddy likes a slow warm up.',
+        status: 'active',
+        lastConfirmedDate: null
+    }
+];
 const inboxData = [
     { id: 1, walkerId: 1, lastMessage: "Sounds good, see you then!", unread: false },
     { id: 3, walkerId: 3, lastMessage: "Yes, I can be there a few minutes early.", unread: true },
@@ -28,6 +45,135 @@ const paymentData = {
     card: { type: 'Visa', last4: '4242', expiry: '12/26'},
     transactions: [{date: '2025-09-11', desc: 'Walk with Jordan L.', amount: 25.00}, {date: '2025-09-09', desc: 'Walk with Alex R.', amount: 40.00}]
 };
+
+// --- RECURRING WALK HELPERS ---
+const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function getRecurringPlanById(planId) {
+    return recurringWalkPlans.find(plan => plan.id === planId);
+}
+
+function normalizeDays(days = []) {
+    return Array.from(new Set(days.map(day => parseInt(day, 10)).filter(day => day >= 0 && day <= 6))).sort((a, b) => a - b);
+}
+
+function createRecurringPlan(data) {
+    const plan = {
+        id: Date.now(),
+        label: data.label?.trim() || '',
+        dogIds: Array.isArray(data.dogIds) ? Array.from(new Set(data.dogIds.map(id => parseInt(id, 10)))) : [],
+        walkerId: data.walkerId ? parseInt(data.walkerId, 10) : null,
+        daysOfWeek: normalizeDays(data.daysOfWeek),
+        time: data.time || '09:00',
+        duration: data.duration ? parseInt(data.duration, 10) : 30,
+        startDate: data.startDate,
+        address: data.address?.trim() || '',
+        notes: data.notes?.trim() || '',
+        status: 'active',
+        lastConfirmedDate: null
+    };
+    recurringWalkPlans.push(plan);
+    return plan;
+}
+
+function updateRecurringPlan(planId, updates = {}) {
+    const plan = getRecurringPlanById(planId);
+    if (!plan) return null;
+    if (updates.daysOfWeek) plan.daysOfWeek = normalizeDays(updates.daysOfWeek);
+    if (updates.dogIds) plan.dogIds = Array.from(new Set(updates.dogIds.map(id => parseInt(id, 10))));
+    if (typeof updates.walkerId !== 'undefined') plan.walkerId = parseInt(updates.walkerId, 10);
+    if (typeof updates.time === 'string') plan.time = updates.time;
+    if (updates.duration) plan.duration = parseInt(updates.duration, 10);
+    if (typeof updates.startDate === 'string') plan.startDate = updates.startDate;
+    if (typeof updates.address === 'string') plan.address = updates.address.trim();
+    if (typeof updates.notes === 'string') plan.notes = updates.notes.trim();
+    if (typeof updates.label === 'string') plan.label = updates.label.trim();
+    return plan;
+}
+
+function toggleRecurringPlanStatus(planId) {
+    const plan = getRecurringPlanById(planId);
+    if (!plan) return null;
+    plan.status = plan.status === 'active' ? 'paused' : 'active';
+    return plan.status;
+}
+
+function deleteRecurringPlan(planId) {
+    const index = recurringWalkPlans.findIndex(plan => plan.id === planId);
+    if (index >= 0) {
+        recurringWalkPlans.splice(index, 1);
+        return true;
+    }
+    return false;
+}
+
+function generatePlanOccurrences(plan, count = 3, fromDate = new Date()) {
+    if (!plan || !Array.isArray(plan.daysOfWeek) || plan.daysOfWeek.length === 0) return [];
+    const occurrences = [];
+    const start = plan.startDate ? new Date(`${plan.startDate}T00:00:00`) : new Date();
+    start.setHours(0, 0, 0, 0);
+    const base = new Date(fromDate);
+    base.setHours(0, 0, 0, 0);
+    const cursor = base < start ? start : base;
+
+    for (let offset = 0; occurrences.length < count && offset < 365; offset++) {
+        const day = new Date(cursor);
+        day.setDate(cursor.getDate() + offset);
+        if (plan.daysOfWeek.includes(day.getDay()) && day >= start) {
+            occurrences.push({
+                date: day.toISOString().split('T')[0],
+                time: plan.time
+            });
+        }
+    }
+    return occurrences;
+}
+
+function confirmRecurringOccurrence(planId, occurrence) {
+    const plan = getRecurringPlanById(planId);
+    if (!plan || !occurrence) return null;
+    const walker = walkerData.find(w => w.id === plan.walkerId);
+    const dogs = plan.dogIds.map(id => dogData.find(dog => dog.id === id)).filter(Boolean);
+    if (!walker || dogs.length === 0) return null;
+
+    const durationMultiplier = plan.duration === 60 ? 1.6 : plan.duration / 30;
+    const computedPrice = Math.round((walker.price * durationMultiplier) * 100) / 100;
+    const newWalk = {
+        id: Date.now(),
+        date: occurrence.date,
+        time: occurrence.time || plan.time,
+        duration: plan.duration,
+        walker,
+        dogs,
+        price: computedPrice,
+        status: 'Upcoming',
+        address: plan.address,
+        note: plan.notes,
+        source: 'Recurring Plan'
+    };
+    walkHistoryData.unshift(newWalk);
+    plan.lastConfirmedDate = occurrence.date;
+    return newWalk;
+}
+
+function formatPlanDays(days = []) {
+    if (!days.length) return 'No days selected';
+    return days.map(day => DAY_LABELS[day] || '').filter(Boolean).join(', ');
+}
+
+function formatDateDisplay(dateString) {
+    if (!dateString) return '';
+    const date = new Date(`${dateString}T00:00:00`);
+    if (Number.isNaN(date.valueOf())) return dateString;
+    return date.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+function formatTimeDisplay(timeString = '09:00') {
+    const [hours, minutes] = timeString.split(':').map(Number);
+    const date = new Date();
+    date.setHours(Number.isNaN(hours) ? 9 : hours, Number.isNaN(minutes) ? 0 : minutes, 0, 0);
+    return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
 
 // --- APP STATE ---
 const appState = { currentPage: 'page-home' };
@@ -396,7 +542,417 @@ function renderLiveTracking(walkId) {
 
 function renderRecurringWalksPage() {
     const container = document.getElementById('page-recurring-walks');
-    container.innerHTML = `<div class="page-header"><button class="back-btn" data-target="page-home"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg></button><h1>Scheduled Walks</h1></div><div class="space-y-4"><div class="glass-card p-4"><div class="flex justify-between items-center"><p class="font-bold">Mon, Wed, Fri</p><span class="text-sm bg-green-500/50 px-2 py-1 rounded-full">Active</span></div><p class="text-sm opacity-80">9:00 AM, 30 min with Alex R.</p></div><button class="btn btn-primary w-full">Set Up New Schedule</button></div>`;
+    if (!container) return;
+
+    container.innerHTML = `
+        <div class="page-header">
+            <button class="back-btn" data-target="page-home" aria-label="Back to Home">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+            </button>
+            <h1>Scheduled Walks</h1>
+        </div>
+        <div class="space-y-6" id="recurring-page-content">
+            <div id="recurring-empty-state" class="glass-card p-5 text-center space-y-2 ${recurringWalkPlans.length ? 'hidden' : ''}">
+                <div class="text-4xl">🗓️</div>
+                <h2 class="text-lg font-semibold">No recurring walks yet</h2>
+                <p class="text-sm opacity-80">Create a schedule so your pups never miss their favorite stroll.</p>
+            </div>
+            <div id="recurring-plan-list" class="space-y-4"></div>
+            <button class="btn btn-primary w-full" id="recurring-schedule-btn">Set Up New Schedule</button>
+            <div id="recurring-plan-form-wrapper" class="scheduler-form hidden">
+                <form id="recurring-plan-form" class="glass-card p-5 space-y-5" novalidate>
+                    <div class="flex justify-between items-center">
+                        <div>
+                            <h2 class="text-lg font-semibold" id="recurring-form-title">Set Up New Schedule</h2>
+                            <p class="text-sm opacity-70" id="recurring-form-subtitle">Pick the routine that fits your pups best.</p>
+                        </div>
+                        <button type="button" class="icon-button" id="recurring-form-close" aria-label="Close schedule form">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                        </button>
+                    </div>
+                    <div class="space-y-4">
+                        <div>
+                            <h3 class="text-sm font-semibold mb-2">Plan nickname <span class="opacity-60">(optional)</span></h3>
+                            <div class="input-group"><input type="text" id="recurring-plan-label" class="input-field" placeholder="e.g., Morning crew"></div>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-semibold mb-2">Pick days</h3>
+                            <div id="recurring-day-picker" class="day-picker-grid"></div>
+                        </div>
+                        <div class="grid grid-cols-2 gap-4">
+                            <div>
+                                <h3 class="text-sm font-semibold mb-2">Start date</h3>
+                                <div class="input-group"><input type="date" id="recurring-start-date" class="input-field"></div>
+                            </div>
+                            <div>
+                                <h3 class="text-sm font-semibold mb-2">Walk time</h3>
+                                <div class="input-group"><input type="time" id="recurring-time" class="input-field" value="09:00"></div>
+                            </div>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-semibold mb-2">Duration</h3>
+                            <div id="recurring-duration-options" class="grid grid-cols-2 gap-3"></div>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-semibold mb-2">Select dogs</h3>
+                            <div id="recurring-dog-selection" class="grid grid-cols-2 gap-3"></div>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-semibold mb-2">Preferred walker</h3>
+                            <div class="flex flex-wrap gap-2 mb-3" id="recurring-filter-chips">
+                                <button type="button" class="chip btn btn-secondary active" data-filter="nearest">Nearest</button>
+                                <button type="button" class="chip btn btn-secondary" data-filter="favorites">Favorites ★</button>
+                                <button type="button" class="chip btn btn-secondary" data-filter="price">Price</button>
+                                <button type="button" class="chip btn btn-secondary" data-filter="top-rated">Top Rated</button>
+                            </div>
+                            <div id="recurring-walker-list" class="space-y-3"></div>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-semibold mb-2">Pickup address</h3>
+                            <div class="input-group"><input type="text" id="recurring-address" class="input-field" placeholder="e.g., 123 Bark Ave"></div>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-semibold mb-2">Notes for walker</h3>
+                            <div class="input-group"><textarea id="recurring-notes" class="input-field h-24 resize-none" placeholder="Anything special to remember?"></textarea></div>
+                        </div>
+                    </div>
+                    <div class="grid grid-cols-2 gap-3">
+                        <button type="button" class="btn btn-secondary" id="recurring-form-cancel">Cancel</button>
+                        <button type="submit" class="btn btn-primary" id="recurring-form-submit">Save Schedule</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    `;
+
+    const planListEl = container.querySelector('#recurring-plan-list');
+    const emptyStateEl = container.querySelector('#recurring-empty-state');
+    const formWrapper = container.querySelector('#recurring-plan-form-wrapper');
+    const formEl = container.querySelector('#recurring-plan-form');
+    const dayPickerEl = container.querySelector('#recurring-day-picker');
+    const dogSelectionEl = container.querySelector('#recurring-dog-selection');
+    const durationOptionsEl = container.querySelector('#recurring-duration-options');
+    const walkerListEl = container.querySelector('#recurring-walker-list');
+    const filterChipsEl = container.querySelector('#recurring-filter-chips');
+    const scheduleBtn = container.querySelector('#recurring-schedule-btn');
+    const closeBtn = container.querySelector('#recurring-form-close');
+    const cancelBtn = container.querySelector('#recurring-form-cancel');
+    const submitBtn = container.querySelector('#recurring-form-submit');
+    const startDateInput = container.querySelector('#recurring-start-date');
+    const timeInput = container.querySelector('#recurring-time');
+    const labelInput = container.querySelector('#recurring-plan-label');
+    const addressInput = container.querySelector('#recurring-address');
+    const notesInput = container.querySelector('#recurring-notes');
+
+    let editingPlanId = null;
+    const todayIso = new Date().toISOString().split('T')[0];
+    startDateInput.min = todayIso;
+
+    function toggleForm(show) {
+        if (show) {
+            formWrapper.classList.remove('hidden');
+            formWrapper.classList.add('active');
+        } else {
+            formWrapper.classList.add('hidden');
+            formWrapper.classList.remove('active');
+        }
+    }
+
+    function resetForm() {
+        formEl.reset();
+        editingPlanId = null;
+        labelInput.value = '';
+        addressInput.value = '';
+        notesInput.value = '';
+        timeInput.value = '09:00';
+        startDateInput.value = todayIso;
+        startDateInput.min = todayIso;
+        renderDayPicker([]);
+        renderDogSelection([]);
+        renderDurationOptions(30);
+        renderWalkerOptions(walkerData, null);
+        filterChipsEl.querySelectorAll('button').forEach((btn, index) => btn.classList.toggle('active', index === 0));
+        submitBtn.textContent = 'Save Schedule';
+        container.querySelector('#recurring-form-title').textContent = 'Set Up New Schedule';
+        container.querySelector('#recurring-form-subtitle').textContent = 'Pick the routine that fits your pups best.';
+    }
+
+    function renderDayPicker(selected = []) {
+        dayPickerEl.innerHTML = DAY_LABELS.map((label, index) => `<button type="button" class="day-toggle${selected.includes(index) ? ' active' : ''}" data-day="${index}">${label}</button>`).join('');
+    }
+
+    function renderDogSelection(selectedIds = []) {
+        dogSelectionEl.innerHTML = dogData.map(dog => `
+            <label class="checkable-card">
+                <input type="checkbox" name="recurring-dogs" value="${dog.id}" ${selectedIds.includes(dog.id) ? 'checked' : ''}>
+                <div class="card-content glass-card p-4 flex flex-col items-center">
+                    <span class="text-3xl">${dog.avatar}</span>
+                    <span class="font-semibold mt-2 text-sm">${dog.name}</span>
+                </div>
+                <div class="checkmark"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg></div>
+            </label>
+        `).join('');
+    }
+
+    function renderDurationOptions(selectedDuration = 30) {
+        durationOptionsEl.innerHTML = [
+            { value: 30, label: '30 min', price: '$25' },
+            { value: 60, label: '60 min', price: '$40' }
+        ].map(option => `
+            <label class="checkable-card">
+                <input type="radio" name="recurring-duration" value="${option.value}" ${option.value === selectedDuration ? 'checked' : ''}>
+                <div class="card-content glass-card p-4">
+                    <div class="text-lg font-semibold">${option.label}</div>
+                    <div class="text-sm opacity-70">${option.price}</div>
+                </div>
+                <div class="checkmark"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg></div>
+            </label>
+        `).join('');
+    }
+
+    function renderWalkerOptions(walkers, selectedId = null) {
+        if (!walkerListEl) return;
+        if (!walkers.length) {
+            walkerListEl.innerHTML = '<p class="text-sm opacity-70 text-center">No walkers match your filters.</p>';
+            return;
+        }
+        walkerListEl.innerHTML = walkers.map(walker => {
+            const isSelected = walker.id === selectedId;
+            return `
+            <label class="walker-option glass-card p-4 flex items-center gap-3${isSelected ? ' selected' : ''}">
+                <input type="radio" class="hidden" name="recurring-walker" value="${walker.id}" ${isSelected ? 'checked' : ''}>
+                <img src="${walker.avatar}" alt="${walker.name}" class="w-12 h-12 rounded-full object-cover">
+                <div class="flex-1">
+                    <div class="flex items-center gap-2">
+                        <span class="font-semibold">${walker.name}</span>
+                        ${walker.verified ? '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="#60a5fa" stroke="white" stroke-width="1"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>' : ''}
+                    </div>
+                    <p class="text-xs opacity-70">★ ${walker.rating.toFixed(1)} • $${walker.price.toFixed(0)}</p>
+                </div>
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="selection-indicator"><polyline points="20 6 9 17 4 12"></polyline></svg>
+            </label>
+        `; }).join('');
+        walkerListEl.querySelectorAll('input[name="recurring-walker"]').forEach(input => {
+            const card = input.closest('.walker-option');
+            if (input.checked) card?.classList.add('selected');
+            input.addEventListener('change', () => {
+                walkerListEl.querySelectorAll('.walker-option').forEach(option => option.classList.remove('selected'));
+                card?.classList.add('selected');
+            });
+        });
+    }
+
+    function getSelectedDays() {
+        return Array.from(dayPickerEl.querySelectorAll('.day-toggle.active')).map(btn => parseInt(btn.dataset.day, 10));
+    }
+
+    function getSelectedDogIds() {
+        return Array.from(dogSelectionEl.querySelectorAll('input[name="recurring-dogs"]:checked')).map(cb => parseInt(cb.value, 10));
+    }
+
+    function getSelectedWalkerId() {
+        const selected = walkerListEl.querySelector('input[name="recurring-walker"]:checked');
+        return selected ? parseInt(selected.value, 10) : null;
+    }
+
+    function populateForm(plan) {
+        editingPlanId = plan?.id ?? null;
+        filterChipsEl.querySelectorAll('button').forEach((btn, index) => btn.classList.toggle('active', index === 0));
+        renderDayPicker(plan?.daysOfWeek || []);
+        renderDogSelection(plan?.dogIds || []);
+        renderDurationOptions(plan?.duration || 30);
+        renderWalkerOptions(walkerData, plan?.walkerId ?? null);
+        const planStart = plan?.startDate || todayIso;
+        startDateInput.value = planStart;
+        startDateInput.min = plan?.startDate && plan.startDate < todayIso ? plan.startDate : todayIso;
+        timeInput.value = plan?.time || '09:00';
+        labelInput.value = plan?.label || '';
+        addressInput.value = plan?.address || '';
+        notesInput.value = plan?.notes || '';
+        submitBtn.textContent = editingPlanId ? 'Update Schedule' : 'Save Schedule';
+        container.querySelector('#recurring-form-title').textContent = editingPlanId ? 'Edit Schedule' : 'Set Up New Schedule';
+        container.querySelector('#recurring-form-subtitle').textContent = editingPlanId ? 'Tweak the routine without missing a beat.' : 'Pick the routine that fits your pups best.';
+        toggleForm(true);
+    }
+
+    function renderPlans() {
+        if (!planListEl) return;
+        if (!recurringWalkPlans.length) {
+            planListEl.innerHTML = '';
+            emptyStateEl?.classList.remove('hidden');
+            return;
+        }
+        emptyStateEl?.classList.add('hidden');
+        planListEl.innerHTML = recurringWalkPlans.map(plan => {
+            const walker = walkerData.find(w => w.id === plan.walkerId);
+            const dogs = plan.dogIds.map(id => dogData.find(d => d.id === id)?.name).filter(Boolean).join(', ');
+            const nextOccurrence = generatePlanOccurrences(plan, 1)[0];
+            const nextLabel = nextOccurrence ? `${formatDateDisplay(nextOccurrence.date)} at ${formatTimeDisplay(plan.time)}` : 'No upcoming days';
+            const statusClass = plan.status === 'active' ? 'status-badge--active' : 'status-badge--paused';
+            const statusLabel = plan.status === 'active' ? 'Active' : 'Paused';
+            const nextDateAttr = nextOccurrence?.date || '';
+            const disabledAttr = plan.status !== 'active' || !nextOccurrence ? 'disabled' : '';
+            const subtitle = plan.label ? (walker ? walker.name : 'Walker TBD') : formatPlanDays(plan.daysOfWeek);
+            return `
+                <div class="glass-card p-5 space-y-3 recurring-plan-card" data-plan-id="${plan.id}">
+                    <div class="flex justify-between gap-3 items-start">
+                        <div>
+                            <p class="font-semibold text-base">${plan.label || formatPlanDays(plan.daysOfWeek)}</p>
+                            <p class="text-sm opacity-70">${subtitle}</p>
+                        </div>
+                        <span class="status-badge ${statusClass}">${statusLabel}</span>
+                    </div>
+                    <div class="text-sm opacity-80 space-y-1">
+                        <p>${formatPlanDays(plan.daysOfWeek)} • ${formatTimeDisplay(plan.time)} • ${plan.duration} min</p>
+                        <p>Walker: ${walker ? walker.name : 'Select during booking'}</p>
+                        <p>Dogs: ${dogs || 'Select dogs'}</p>
+                        <p class="next-occurrence">Next: ${nextLabel}</p>
+                    </div>
+                    <div class="flex flex-wrap gap-2 pt-1">
+                        <button type="button" class="btn btn-secondary flex-1" data-action="review" data-occurrence-date="${nextDateAttr}" ${!nextOccurrence ? 'disabled' : ''}>Review next walk</button>
+                        <button type="button" class="btn btn-primary flex-1" data-action="confirm" data-occurrence-date="${nextDateAttr}" ${disabledAttr}>Confirm next walk</button>
+                    </div>
+                    <div class="flex flex-wrap gap-2">
+                        <button type="button" class="btn btn-secondary flex-1" data-action="edit">Edit</button>
+                        <button type="button" class="btn btn-secondary flex-1" data-action="toggle">${plan.status === 'active' ? 'Pause' : 'Resume'}</button>
+                        <button type="button" class="btn btn-danger flex-1" data-action="delete">Cancel plan</button>
+                    </div>
+                </div>
+            `;
+        }).join('');
+    }
+
+    renderDayPicker([]);
+    renderDogSelection([]);
+    renderDurationOptions(30);
+    renderWalkerOptions(walkerData, null);
+    renderPlans();
+    startDateInput.value = todayIso;
+
+    scheduleBtn.addEventListener('click', () => {
+        vibrate();
+        resetForm();
+        toggleForm(true);
+    });
+
+    closeBtn.addEventListener('click', () => {
+        vibrate();
+        resetForm();
+        toggleForm(false);
+    });
+
+    cancelBtn.addEventListener('click', () => {
+        vibrate();
+        resetForm();
+        toggleForm(false);
+    });
+
+    dayPickerEl.addEventListener('click', e => {
+        const button = e.target.closest('.day-toggle');
+        if (!button) return;
+        vibrate();
+        button.classList.toggle('active');
+    });
+
+    filterChipsEl.addEventListener('click', e => {
+        const button = e.target.closest('button[data-filter]');
+        if (!button) return;
+        vibrate();
+        filterChipsEl.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
+        button.classList.add('active');
+        let filtered = [...walkerData];
+        const filter = button.dataset.filter;
+        if (filter === 'price') filtered.sort((a, b) => a.price - b.price);
+        else if (filter === 'top-rated') filtered.sort((a, b) => b.rating - a.rating);
+        else if (filter === 'favorites') filtered = filtered.filter(w => w.favorite);
+        renderWalkerOptions(filtered, getSelectedWalkerId());
+    });
+
+    walkerListEl.addEventListener('change', e => {
+        if (e.target.name === 'recurring-walker') {
+            vibrate();
+        }
+    });
+
+    planListEl.addEventListener('click', e => {
+        const actionBtn = e.target.closest('[data-action]');
+        if (!actionBtn) return;
+        const planCard = actionBtn.closest('.recurring-plan-card');
+        if (!planCard) return;
+        const planId = parseInt(planCard.dataset.planId, 10);
+        const plan = getRecurringPlanById(planId);
+        if (!plan) return;
+        vibrate();
+        const action = actionBtn.dataset.action;
+        if (action === 'edit') {
+            populateForm(plan);
+        } else if (action === 'toggle') {
+            toggleRecurringPlanStatus(planId);
+            renderPlans();
+        } else if (action === 'delete') {
+            if (editingPlanId === planId) {
+                resetForm();
+                toggleForm(false);
+            }
+            deleteRecurringPlan(planId);
+            renderPlans();
+        } else if (action === 'confirm') {
+            if (plan.status !== 'active') return;
+            const date = actionBtn.dataset.occurrenceDate;
+            if (!date) return;
+            confirmRecurringOccurrence(planId, { date, time: plan.time });
+            renderPlans();
+        } else if (action === 'review') {
+            const date = actionBtn.dataset.occurrenceDate;
+            if (!date) return;
+            appState.prefillBooking = {
+                date,
+                time: plan.time,
+                duration: plan.duration,
+                walkerId: plan.walkerId,
+                dogIds: plan.dogIds,
+                address: plan.address,
+                notes: plan.notes
+            };
+            launchBookingFlow('recurring-plan');
+        }
+    });
+
+    formEl.addEventListener('submit', e => {
+        e.preventDefault();
+        vibrate();
+        const selectedDays = getSelectedDays();
+        const selectedDogs = getSelectedDogIds();
+        const selectedWalkerId = getSelectedWalkerId();
+        const duration = parseInt((formEl.querySelector('input[name="recurring-duration"]:checked')?.value) || '30', 10);
+        const startDate = startDateInput.value || todayIso;
+        const time = timeInput.value || '09:00';
+        if (!selectedDays.length) { alert('Select at least one day of the week.'); return; }
+        if (!selectedDogs.length) { alert('Select at least one dog.'); return; }
+        if (!selectedWalkerId) { alert('Choose a preferred walker.'); return; }
+        if (!addressInput.value.trim()) { alert('Add a pickup address so your walker knows where to go.'); return; }
+
+        const payload = {
+            label: labelInput.value,
+            daysOfWeek: selectedDays,
+            dogIds: selectedDogs,
+            walkerId: selectedWalkerId,
+            duration,
+            startDate,
+            time,
+            address: addressInput.value,
+            notes: notesInput.value
+        };
+
+        if (editingPlanId) {
+            updateRecurringPlan(editingPlanId, payload);
+        } else {
+            createRecurringPlan(payload);
+        }
+        renderPlans();
+        resetForm();
+        toggleForm(false);
+    });
 }
 
 function renderPaymentsPage() {
@@ -411,6 +967,8 @@ function renderPromotionsPage() {
 
 function fullInitBookingFlow() {
     const bookingState = {};
+    const prefill = appState.prefillBooking;
+    let hasAppliedPrefillWalker = false;
     let currentScreen = 0;
     const screens = document.querySelectorAll('#page-booking-flow .screen');
     const progressBar = { line: document.getElementById('progressLineActive'), steps: [document.getElementById('step-0'), document.getElementById('step-1'), document.getElementById('step-2')] };
@@ -451,11 +1009,24 @@ function fullInitBookingFlow() {
     }
 
     // Init Screen 1
+    const dateInput = document.getElementById('walk-date');
+    const timeInput = document.getElementById('walk-time');
+    const addressInput = document.getElementById('address');
+    const instructionsInput = document.getElementById('instructions');
     const tomorrow = new Date(); tomorrow.setDate(tomorrow.getDate() + 1);
-    document.getElementById('walk-date').value = tomorrow.toISOString().split('T')[0];
-    document.getElementById('walk-date').min = tomorrow.toISOString().split('T')[0];
-    document.getElementById('walk-time').value = '10:00';
-    document.getElementById('dog-selection').innerHTML = dogData.map(dog => `<label class="checkable-card"><input type="checkbox" name="dogs" value="${dog.id}"><div class="card-content glass-card p-4 flex flex-col items-center"><span class="text-4xl">${dog.avatar}</span><span class="font-semibold mt-2">${dog.name}</span></div><div class="checkmark"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg></div></label>`).join('');
+    const tomorrowIso = tomorrow.toISOString().split('T')[0];
+    const minDate = prefill?.date && prefill.date < tomorrowIso ? prefill.date : tomorrowIso;
+    dateInput.value = prefill?.date || tomorrowIso;
+    dateInput.min = minDate;
+    timeInput.value = prefill?.time || '10:00';
+    if (prefill?.address) addressInput.value = prefill.address;
+    if (prefill?.notes) instructionsInput.value = prefill.notes;
+    const preselectedDogs = prefill?.dogIds || [];
+    document.getElementById('dog-selection').innerHTML = dogData.map(dog => `<label class="checkable-card"><input type="checkbox" name="dogs" value="${dog.id}" ${preselectedDogs.includes(dog.id) ? 'checked' : ''}><div class="card-content glass-card p-4 flex flex-col items-center"><span class="text-4xl">${dog.avatar}</span><span class="font-semibold mt-2">${dog.name}</span></div><div class="checkmark"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg></div></label>`).join('');
+    if (prefill?.duration) {
+        const durationRadio = document.querySelector(`input[name="service"][value="${prefill.duration}"]`);
+        if (durationRadio) durationRadio.checked = true;
+    }
 
     function validateScreen1() {
         const serviceChecked = document.querySelector('input[name="service"]:checked');
@@ -486,6 +1057,14 @@ function fullInitBookingFlow() {
                 walkerList.querySelectorAll('.glass-card').forEach(c => c.style.borderColor = 'var(--glass-border)');
                 e.target.nextElementSibling.style.borderColor = 'var(--primary-color-light)';
             }));
+            if (prefill?.walkerId && !hasAppliedPrefillWalker) {
+                const targetRadio = walkerList.querySelector(`input[name="walker"][value="${prefill.walkerId}"]`);
+                if (targetRadio) {
+                    targetRadio.checked = true;
+                    targetRadio.dispatchEvent(new Event('change'));
+                    hasAppliedPrefillWalker = true;
+                }
+            }
             walkerList.querySelectorAll('.view-profile-btn').forEach(btn => btn.addEventListener('click', e => {
                 e.stopPropagation();
                 goToPage('page-walker-profile', { walkerId: parseInt(e.target.dataset.walkerId), backTarget: 'page-booking-flow' });
@@ -532,6 +1111,7 @@ function fullInitBookingFlow() {
     document.getElementById('toScreen3Btn').addEventListener('click', () => { renderReviewScreen(); goToBookingScreen(2); });
     document.getElementById('backTo2Btn').addEventListener('click', () => goToBookingScreen(1));
     document.getElementById('bookWalkBtn').addEventListener('click', showSuccessModal);
+    appState.prefillBooking = null;
 }
 
 function initOnboarding() {


### PR DESCRIPTION
## Summary
- add recurring plan state helpers to create, update, pause, and delete recurring walk schedules while logging confirmed occurrences
- expand the recurring walks page with a scheduler form, plan list, and plan action handlers that can prefill the booking flow
- refresh styling for the scheduler controls, status badges, and plan cards to stay consistent with the glass-card aesthetic

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d8386d9894832f974809eba05dff6c