### PR TITLE
Remove onboarding pages and start directly on home screen

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -54,7 +54,7 @@ body::after {
 
 /* App Layout */
 .app-container {
-    display: none; /* Hide by default to let JS control visibility */
+    display: flex;
     flex-direction: column;
     height: 100%;
 }
@@ -359,33 +359,6 @@ body::after {
 .favorite-btn.favorited { color: #F472B6; /* A nice pink */ }
 .favorite-btn svg { stroke: currentColor; transition: fill 0.3s ease; }
 .favorite-btn.favorited svg { fill: currentColor; }
-
-/* Onboarding Styles */
-#page-onboarding {
-    display: none; /* Hide by default */
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
-    text-align: center;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: 1000;
-    background: linear-gradient(135deg, #1e0033 0%, #3d1c5a 50%, #5f3781 100%);
-}
-#page-onboarding.active {
-    display: flex;
-}
-.onboarding-slides { display: flex; transition: transform 0.5s ease-in-out; width: 300%; }
-.onboarding-slide { width: 100%; padding: 2rem; display: flex; flex-direction: column; justify-content: center; align-items: center; gap: 1rem; }
-.onboarding-icon { width: 100px; height: 100px; background: var(--glass-bg); border-radius: 50%; display: flex; justify-content: center; align-items: center; border: 1px solid var(--glass-border); }
-.onboarding-dots { display: flex; gap: 0.5rem; margin-top: 2rem; }
-.onboarding-dot { width: 10px; height: 10px; background: var(--glass-border); border-radius: 50%; transition: all 0.3s ease; }
-.onboarding-dot.active { background: var(--text-color); transform: scale(1.2); }
-
 
 /* Success Modal */
 .modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.6); backdrop-filter: blur(5px); display: flex; justify-content: center; align-items: center; opacity: 0; visibility: hidden; transition: all 0.3s ease-in-out; z-index: 100; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -254,13 +254,10 @@ const goToPage = (pageId, context = null) => {
     const targetPage = document.getElementById(pageId);
     if (targetPage) {
         targetPage.classList.add('active');
-        const isFullScreenPage = ['page-booking-flow', 'page-live-tracking', 'page-chat', 'page-onboarding'].includes(pageId);
+        const isFullScreenPage = ['page-booking-flow', 'page-live-tracking', 'page-chat'].includes(pageId);
 
         if (document.querySelector('.bottom-nav')) {
             document.querySelector('.bottom-nav').style.display = isFullScreenPage ? 'none' : 'flex';
-        }
-        if (appContainer) {
-            appContainer.style.display = pageId === 'page-onboarding' ? 'none' : 'flex';
         }
     }
 
@@ -1114,58 +1111,6 @@ function fullInitBookingFlow() {
     appState.prefillBooking = null;
 }
 
-function initOnboarding() {
-    let currentSlide = 0;
-    const slidesContainer = document.getElementById('onboarding-slides-container');
-    const dotsContainer = document.getElementById('onboarding-dots-container');
-    const nextBtn = document.getElementById('onboarding-next-btn');
-    const totalSlides = 3;
-
-    for(let i=0; i < totalSlides; i++) {
-        dotsContainer.innerHTML += `<div class="onboarding-dot ${i === 0 ? 'active' : ''}" data-slide="${i}"></div>`;
-    }
-    const dots = dotsContainer.querySelectorAll('.onboarding-dot');
-
-    function updateOnboardingUI() {
-        slidesContainer.style.transform = `translateX(-${currentSlide * (100 / totalSlides)}%)`;
-        dots.forEach((dot, i) => dot.classList.toggle('active', i === currentSlide));
-        if (currentSlide === totalSlides - 1) {
-            nextBtn.textContent = 'Get Started';
-        } else {
-            nextBtn.textContent = 'Next';
-        }
-    }
-
-    nextBtn.addEventListener('click', () => {
-        if (currentSlide < totalSlides - 1) {
-            currentSlide++;
-            updateOnboardingUI();
-        } else {
-            try {
-                localStorage.setItem('onboardingComplete', 'true');
-            } catch(e) { console.error("Could not set localStorage.") }
-            goToPage('page-home');
-        }
-    });
-}
-
-// --- APP INITIALIZATION ---
-function initApp() { 
-    let onboardingComplete = false;
-    try {
-        onboardingComplete = localStorage.getItem('onboardingComplete') === 'true';
-    } catch (e) {
-        console.error("Could not access localStorage. Defaulting to onboarding.", e);
-    }
-
-    if (onboardingComplete) {
-        goToPage('page-home');
-    } else {
-        initOnboarding();
-        goToPage('page-onboarding');
-    }
-}
-
 // Add main event listeners
 function handleNavItemClick(item) {
     const target = item?.dataset?.target;
@@ -1193,6 +1138,6 @@ document.getElementById('cta-book-walk').addEventListener('click', () => launchB
 document.getElementById('cta-recurring-walk').addEventListener('click', () => goToPage('page-recurring-walks'));
 document.getElementById('btn-add-dog').addEventListener('click', () => goToPage('page-dog-form'));
 
-// Start the app
-initApp();
+// --- APP INITIALIZATION ---
+goToPage('page-home');
     });

--- a/index.html
+++ b/index.html
@@ -13,32 +13,6 @@
 </head>
 <body>
 
-    <div id="page-onboarding" class="page">
-        <div style="width:100vw; overflow:hidden;">
-            <div class="onboarding-slides" id="onboarding-slides-container">
-                <div class="onboarding-slide">
-                    <div class="onboarding-icon"><svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/><path d="m16 14-4 4-2-2"/></svg></div>
-                    <h2 class="text-2xl font-bold">Plan the Perfect Walk</h2>
-                    <p class="opacity-80">Easily schedule walks that fit your and your dog's needs.</p>
-                </div>
-                <div class="onboarding-slide">
-                    <div class="onboarding-icon"><svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></div>
-                    <h2 class="text-2xl font-bold">Choose a Trusted Walker</h2>
-                    <p class="opacity-80">Select from a list of verified, top-rated walkers in your area.</p>
-                </div>
-                <div class="onboarding-slide">
-                    <div class="onboarding-icon"><svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"></path><circle cx="12" cy="10" r="3"></circle></svg></div>
-                    <h2 class="text-2xl font-bold">Track Every Step</h2>
-                    <p class="opacity-80">Follow along with live GPS tracking and get photo updates.</p>
-                </div>
-            </div>
-        </div>
-        <div class="onboarding-dots" id="onboarding-dots-container"></div>
-        <div class="mt-8 px-8 w-full max-w-sm">
-            <button id="onboarding-next-btn" class="btn btn-primary w-full">Next</button>
-        </div>
-    </div>
-    
     <div class="app-container">
         <!-- MAIN CONTENT AREA FOR ALL PAGES -->
         <main class="main-content">


### PR DESCRIPTION
## Summary
- remove the hard-coded onboarding slides from the HTML markup and related styles
- simplify app initialization to skip onboarding and land on the home dashboard
- ensure the app container renders by default without JS toggling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe3babbb0832f882ce28c88de10e2