### PR TITLE
Refresh Walkies visual system

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,14 +1,21 @@
 /* CSS Variables for Design System */
 :root {
-    --primary-color: #8A2BE2; /* A nice purple */
-    --primary-color-light: #9370DB;
-    --glass-bg: rgba(255, 255, 255, 0.1);
-    --glass-border: rgba(255, 255, 255, 0.2);
-    --text-color: #E0E0E0;
-    --text-color-dark: #333;
-    --shadow-light: 0 8px 32px 0 rgba(31, 38, 135, 0.2);
-    --shadow-strong: 0 12px 40px 0 rgba(31, 38, 135, 0.37);
+    --primary-color: #1dd3b0;
+    --primary-color-light: #5eead4;
+    --primary-color-dark: #0f766e;
+    --accent-muted: rgba(94, 234, 212, 0.16);
+    --surface-bg: rgba(15, 23, 42, 0.58);
+    --surface-bg-strong: rgba(15, 23, 42, 0.72);
+    --surface-border: rgba(148, 163, 184, 0.18);
+    --surface-border-strong: rgba(94, 234, 212, 0.35);
+    --text-color: #f8fafc;
+    --text-color-soft: rgba(248, 250, 252, 0.72);
+    --text-color-dark: #0f172a;
+    --focus-ring: 0 0 0 3px rgba(94, 234, 212, 0.35);
+    --shadow-light: 0 12px 40px rgba(8, 47, 73, 0.32);
+    --shadow-strong: 0 22px 60px rgba(8, 47, 73, 0.5);
     --border-radius: 1rem;
+    --transition-base: all 0.25s ease;
     --font-family: 'Inter', sans-serif;
 }
 
@@ -19,7 +26,7 @@ html, body {
 }
 body {
     font-family: var(--font-family);
-    background: linear-gradient(135deg, #1e0033 0%, #3d1c5a 50%, #5f3781 100%);
+    background: linear-gradient(160deg, #070b14 0%, #0f172a 45%, #0b3a36 100%);
     color: var(--text-color);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -32,20 +39,20 @@ body::before, body::after {
     content: '';
     position: fixed;
     border-radius: 50%;
-    filter: blur(100px);
+    filter: blur(120px);
     z-index: -1;
-    opacity: 0.4;
-    animation: float 20s infinite alternate;
+    opacity: 0.35;
+    animation: float 22s infinite alternate;
 }
 body::before {
-    width: 300px; height: 300px;
-    background-color: #9370DB;
-    top: -50px; left: -100px;
+    width: 320px; height: 320px;
+    background: radial-gradient(circle at 30% 30%, rgba(94, 234, 212, 0.65), transparent 70%);
+    top: -60px; left: -110px;
 }
 body::after {
-    width: 400px; height: 400px;
-    background-color: #8A2BE2;
-    bottom: -100px; right: -150px;
+    width: 420px; height: 420px;
+    background: radial-gradient(circle at 70% 70%, rgba(34, 211, 238, 0.5), transparent 75%);
+    bottom: -120px; right: -160px;
     animation-direction: alternate-reverse;
 }
 @keyframes float {
@@ -62,7 +69,7 @@ body::after {
     flex-grow: 1;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 1.5rem 1rem 8rem 1rem; /* Padding for bottom nav */
+    padding: 2.25rem 1.25rem 8.5rem 1.25rem;
 }
 .page-content-wrapper {
      width: 100%;
@@ -73,6 +80,51 @@ body::after {
 /* Page Transitions */
 .page { display: none; }
 .page.active { display: block; }
+
+.page h1 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    line-height: 1.2;
+    letter-spacing: -0.015em;
+}
+
+.page h2 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 1.35;
+}
+
+.page p {
+    line-height: 1.6;
+    color: var(--text-color-soft);
+}
+
+.section-title {
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-color-soft);
+    margin-bottom: 1rem;
+}
+
+.eyebrow {
+    font-size: 0.75rem;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--text-color-soft);
+}
+
+.hero-title {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--text-color);
+    line-height: 1.1;
+}
+
+.text-soft {
+    color: var(--text-color-soft);
+}
 
 /* Booking Flow Screen Transitions */
 .booking-flow-page .screen {
@@ -94,81 +146,97 @@ body::after {
 
 /* Reusable Components */
 .glass-card {
-    background: var(--glass-bg);
+    background: var(--surface-bg);
     border-radius: var(--border-radius);
-    border: 1px solid var(--glass-border);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--surface-border);
+    backdrop-filter: blur(16px) saturate(135%);
+    -webkit-backdrop-filter: blur(16px) saturate(135%);
     box-shadow: var(--shadow-light);
-    transition: all 0.3s ease;
+    transition: var(--transition-base);
 }
 .glass-card:hover:not(.non-hover) {
     box-shadow: var(--shadow-strong);
     transform: translateY(-4px);
+    border-color: var(--surface-border-strong);
 }
 .btn {
-    padding: 0.875rem 1.5rem;
-    border-radius: 0.75rem;
+    padding: 0.85rem 1.5rem;
+    border-radius: 0.95rem;
     font-weight: 600;
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: var(--transition-base);
     border: none;
     outline: none;
 }
 .btn-primary {
     background: var(--primary-color);
-    color: white;
-    box-shadow: 0 4px 15px rgba(138, 43, 226, 0.4);
+    color: #041f1f;
+    box-shadow: 0 14px 32px rgba(29, 211, 176, 0.28);
 }
 .btn-primary:hover:not(:disabled) {
     background: var(--primary-color-light);
-    box-shadow: 0 6px 20px rgba(147, 112, 219, 0.5);
-    transform: translateY(-2px);
+    color: var(--text-color-dark);
+    box-shadow: 0 18px 38px rgba(94, 234, 212, 0.32);
+    transform: translateY(-1px);
+}
+.btn-primary:active {
+    transform: translateY(0);
+    box-shadow: 0 8px 18px rgba(13, 148, 136, 0.35);
 }
 .btn:disabled {
-    background: rgba(147, 112, 219, 0.4);
+    background: rgba(94, 234, 212, 0.2);
     cursor: not-allowed;
     box-shadow: none;
 }
 .btn-secondary {
-    background: var(--glass-bg);
+    background: rgba(148, 163, 184, 0.14);
     color: var(--text-color);
-    border: 1px solid var(--glass-border);
+    border: 1px solid var(--surface-border);
+}
+.btn-secondary:hover:not(:disabled) {
+    background: rgba(148, 163, 184, 0.22);
+    border-color: rgba(148, 163, 184, 0.35);
 }
 .btn-danger {
-    background: rgba(239, 68, 68, 0.12);
-    color: #fca5a5;
-    border: 1px solid rgba(239, 68, 68, 0.3);
+    background: rgba(248, 113, 113, 0.15);
+    color: #fecaca;
+    border: 1px solid rgba(248, 113, 113, 0.35);
 }
 .btn-danger:hover:not(:disabled) {
-    background: rgba(239, 68, 68, 0.2);
-    color: #fecaca;
-    box-shadow: 0 6px 18px rgba(239, 68, 68, 0.25);
+    background: rgba(248, 113, 113, 0.22);
+    color: #fee2e2;
+    box-shadow: 0 10px 24px rgba(248, 113, 113, 0.28);
+}
+.btn:focus-visible,
+.icon-button:focus-visible,
+.nav-item:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
 }
 .hidden { display: none !important; }
 .icon-button {
-    background: rgba(255, 255, 255, 0.08);
-    border: 1px solid var(--glass-border);
+    background: rgba(148, 163, 184, 0.12);
+    border: 1px solid var(--surface-border);
     border-radius: 999px;
     padding: 0.5rem;
     color: var(--text-color);
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: var(--transition-base);
 }
 .icon-button:hover {
-    background: rgba(255, 255, 255, 0.16);
+    background: rgba(148, 163, 184, 0.22);
 }
 .input-group {
     position: relative;
-    background: var(--glass-bg);
-    border: 1px solid var(--glass-border);
-    border-radius: 0.75rem;
+    background: rgba(15, 23, 42, 0.45);
+    border: 1px solid var(--surface-border);
+    border-radius: 0.95rem;
     display: flex;
     align-items: center;
 }
 .input-group:focus-within {
-    border-color: var(--primary-color-light);
-    box-shadow: 0 0 0 3px rgba(147, 112, 219, 0.4);
+    border-color: var(--surface-border-strong);
+    box-shadow: var(--focus-ring);
 }
 .input-field {
     width: 100%;
@@ -179,23 +247,36 @@ body::after {
     padding: 0.875rem 1rem;
     font-size: 1rem;
 }
-.input-field::placeholder { color: rgba(224, 224, 224, 0.6); }
+.input-field::placeholder { color: rgba(226, 232, 240, 0.5); }
 .page-header {
     display: flex;
     align-items: center;
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
+    gap: 0.75rem;
 }
 .page-header h1 {
     flex-grow: 1;
-    text-align: center;
-    font-size: 1.5rem;
-    font-weight: 700;
 }
 .page-header .back-btn {
     margin-right: auto;
 }
 .page-header .placeholder { /* To balance the back button */
-     width: 40px; 
+     width: 40px;
+}
+
+.back-btn {
+    background: rgba(148, 163, 184, 0.12);
+    border: 1px solid transparent;
+    border-radius: 999px;
+    padding: 0.4rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: var(--transition-base);
+}
+
+.back-btn:hover {
+    background: rgba(148, 163, 184, 0.22);
 }
 
 /* Bottom Navigation */
@@ -206,33 +287,32 @@ body::after {
     right: 0;
     max-width: 420px;
     margin: 0 auto 1.5rem auto;
-    background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(15px);
-    -webkit-backdrop-filter: blur(15px);
-    border-radius: 99px;
-    border: 1px solid rgba(255,255,255,0.1);
+    background: var(--surface-bg-strong);
+    backdrop-filter: blur(18px) saturate(135%);
+    -webkit-backdrop-filter: blur(18px) saturate(135%);
+    border-radius: 1.75rem;
+    border: 1px solid var(--surface-border);
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 0.5rem;
-    padding: 0.75rem 0.75rem;
-    box-shadow: var(--shadow-strong);
+    padding: 0.75rem 0.9rem;
+    box-shadow: var(--shadow-light);
     z-index: 50;
 }
 .nav-item {
     background: none;
     border: none;
-    color: rgba(255,255,255,0.6);
+    color: var(--text-color-soft);
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    font-size: 0.7rem;
-    gap: 0.2rem;
-    padding: 0 0.5rem;
-    transition: all 0.3s ease;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
+    transition: var(--transition-base);
     flex: 1;
-    border-radius: 0.75rem;
+    border-radius: 1rem;
     cursor: pointer;
 }
 .nav-item-icon {
@@ -240,38 +320,62 @@ body::after {
     align-items: center;
     justify-content: center;
 }
-.nav-item svg { color: currentColor; }
-.nav-item.active { color: white; }
-.nav-item.active svg { color: var(--primary-color-light); }
-.nav-item-primary.active svg { color: currentColor; }
+.nav-item svg {
+    color: currentColor;
+    transition: var(--transition-base);
+}
+.nav-item:hover {
+    color: var(--text-color);
+}
+.nav-item.active {
+    color: var(--text-color);
+    background: rgba(148, 163, 184, 0.18);
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+.nav-label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
 
 .nav-item-primary {
-    background: var(--primary-color);
-    color: #fff;
+    background: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-color-light) 100%);
+    color: var(--text-color-dark);
     flex: 0 0 auto;
-    flex-direction: row;
-    gap: 0.5rem;
-    padding: 0.75rem 1.5rem;
-    font-size: 0.85rem;
-    font-weight: 600;
-    box-shadow: 0 12px 32px rgba(138, 43, 226, 0.45);
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    align-self: center;
+    margin-top: -2rem;
+    box-shadow: 0 18px 38px rgba(29, 211, 176, 0.32);
+    border: 1px solid rgba(255, 255, 255, 0.08);
 }
 .nav-item-primary svg {
-    width: 22px;
-    height: 22px;
+    width: 26px;
+    height: 26px;
     color: inherit;
 }
 .nav-item-primary:hover,
 .nav-item-primary:focus-visible {
-    transform: translateY(-2px);
-    box-shadow: 0 16px 36px rgba(147, 112, 219, 0.5);
+    transform: translateY(-3px);
+    box-shadow: 0 22px 48px rgba(94, 234, 212, 0.35);
 }
 .nav-item-primary:focus-visible {
-    outline: 2px solid rgba(255,255,255,0.6);
-    outline-offset: 2px;
+    outline: none;
 }
 .nav-item-primary:active {
     transform: translateY(0);
+}
+.nav-item-primary .nav-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 /* Staggered Animation */
@@ -284,31 +388,31 @@ body::after {
 
 /* Booking Flow Specific Styles */
 #page-booking-flow .progress-bar { display: flex; justify-content: space-between; align-items: center; width: 100%; margin-bottom: 2rem; position: relative; }
-#page-booking-flow .progress-line { position: absolute; height: 4px; background: var(--glass-border); width: 100%; top: 50%; transform: translateY(-50%); z-index: 1; }
-#page-booking-flow .progress-line-active { position: absolute; height: 4px; background: var(--primary-color-light); width: 0; top: 50%; transform: translateY(-50%); z-index: 2; transition: width 0.5s ease-in-out; }
+#page-booking-flow .progress-line { position: absolute; height: 4px; background: rgba(148, 163, 184, 0.22); width: 100%; top: 50%; transform: translateY(-50%); z-index: 1; border-radius: 999px; }
+#page-booking-flow .progress-line-active { position: absolute; height: 4px; background: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-color-light) 100%); width: 0; top: 50%; transform: translateY(-50%); z-index: 2; transition: width 0.5s ease-in-out; border-radius: 999px; }
 #page-booking-flow .progress-step { display: flex; flex-direction: column; align-items: center; z-index: 3; position: relative; }
-#page-booking-flow .progress-icon { width: 40px; height: 40px; border-radius: 50%; background: var(--glass-bg); border: 2px solid var(--glass-border); display: flex; justify-content: center; align-items: center; transition: all 0.4s ease; }
-#page-booking-flow .progress-step.active .progress-icon { background: var(--primary-color-light); border-color: var(--primary-color); transform: scale(1.1); }
+#page-booking-flow .progress-icon { width: 42px; height: 42px; border-radius: 50%; background: rgba(15, 23, 42, 0.55); border: 1px solid var(--surface-border); display: flex; justify-content: center; align-items: center; transition: var(--transition-base); }
+#page-booking-flow .progress-step.active .progress-icon { background: var(--accent-muted); border-color: var(--surface-border-strong); transform: scale(1.05); }
 #page-booking-flow .progress-label { margin-top: 0.5rem; font-size: 0.75rem; font-weight: 500; opacity: 0.7; transition: opacity 0.4s ease; }
 #page-booking-flow .progress-step.active .progress-label { opacity: 1; }
 #page-booking-flow .checkable-card { cursor: pointer; position: relative; text-align: center; }
 #page-booking-flow .checkable-card input { display: none; }
-#page-booking-flow .checkable-card input:checked + .card-content { border-color: var(--primary-color-light); box-shadow: 0 0 0 3px rgba(147, 112, 219, 0.4); }
+#page-booking-flow .checkable-card input:checked + .card-content { border-color: var(--surface-border-strong); box-shadow: 0 0 0 3px rgba(29, 211, 176, 0.28); }
 #page-booking-flow .checkmark { position: absolute; top: 0.75rem; right: 0.75rem; width: 24px; height: 24px; background: rgba(0,0,0,0.3); border-radius: 50%; display: flex; justify-content: center; align-items: center; opacity: 0; transform: scale(0.5); transition: all 0.3s ease; }
 #page-booking-flow .checkable-card input:checked ~ .checkmark { opacity: 1; transform: scale(1); background: var(--primary-color); }
 
 #page-recurring-walks .checkable-card { cursor: pointer; position: relative; text-align: center; }
 #page-recurring-walks .checkable-card input { display: none; }
-#page-recurring-walks .checkable-card .card-content { border: 1px solid var(--glass-border); border-radius: var(--border-radius); transition: all 0.3s ease; }
-#page-recurring-walks .checkable-card input:checked + .card-content { border-color: var(--primary-color-light); box-shadow: 0 0 0 3px rgba(147, 112, 219, 0.4); }
+#page-recurring-walks .checkable-card .card-content { border: 1px solid var(--surface-border); border-radius: var(--border-radius); transition: var(--transition-base); }
+#page-recurring-walks .checkable-card input:checked + .card-content { border-color: var(--surface-border-strong); box-shadow: 0 0 0 3px rgba(29, 211, 176, 0.28); }
 #page-recurring-walks .checkmark { position: absolute; top: 0.5rem; right: 0.5rem; width: 22px; height: 22px; background: rgba(0,0,0,0.3); border-radius: 50%; display: flex; justify-content: center; align-items: center; opacity: 0; transform: scale(0.5); transition: all 0.3s ease; }
 #page-recurring-walks .checkable-card input:checked ~ .checkmark { opacity: 1; transform: scale(1); background: var(--primary-color); }
 
-#page-recurring-walks .walker-option { cursor: pointer; border: 1px solid var(--glass-border); transition: all 0.2s ease; position: relative; }
+#page-recurring-walks .walker-option { cursor: pointer; border: 1px solid var(--surface-border); transition: var(--transition-base); position: relative; }
 #page-recurring-walks .walker-option input { display: none; }
-#page-recurring-walks .walker-option:hover { border-color: var(--primary-color-light); }
+#page-recurring-walks .walker-option:hover { border-color: var(--surface-border-strong); }
 #page-recurring-walks .walker-option .selection-indicator { opacity: 0; transition: opacity 0.2s ease; }
-#page-recurring-walks .walker-option.selected { border-color: var(--primary-color-light); box-shadow: 0 6px 16px rgba(147, 112, 219, 0.2); }
+#page-recurring-walks .walker-option.selected { border-color: var(--surface-border-strong); box-shadow: 0 10px 26px rgba(29, 211, 176, 0.25); }
 #page-recurring-walks .walker-option.selected .selection-indicator { opacity: 1; }
 
 .scheduler-form { animation: fadeIn 0.25s ease; }
@@ -316,20 +420,21 @@ body::after {
 .day-picker-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0.5rem; }
 .day-toggle {
     padding: 0.65rem 0.75rem;
-    border-radius: 0.75rem;
-    border: 1px solid var(--glass-border);
-    background: rgba(255,255,255,0.05);
+    border-radius: 0.85rem;
+    border: 1px solid var(--surface-border);
+    background: rgba(148, 163, 184, 0.12);
     color: var(--text-color);
     font-size: 0.875rem;
     font-weight: 600;
-    transition: all 0.2s ease;
+    transition: var(--transition-base);
 }
 .day-toggle.active {
     background: var(--primary-color);
-    border-color: var(--primary-color-light);
-    box-shadow: 0 6px 16px rgba(147, 112, 219, 0.35);
+    border-color: var(--surface-border-strong);
+    color: var(--text-color-dark);
+    box-shadow: 0 12px 26px rgba(29, 211, 176, 0.35);
 }
-.day-toggle:focus-visible { outline: 2px solid var(--primary-color-light); outline-offset: 2px; }
+.day-toggle:focus-visible { outline: none; }
 
 .status-badge {
     font-size: 0.75rem;
@@ -339,29 +444,30 @@ body::after {
     text-transform: uppercase;
     letter-spacing: 0.04em;
 }
-.status-badge--active { background: rgba(34, 197, 94, 0.18); color: #bbf7d0; border: 1px solid rgba(34, 197, 94, 0.35); }
-.status-badge--paused { background: rgba(234, 179, 8, 0.18); color: #fde68a; border: 1px solid rgba(234, 179, 8, 0.35); }
+.status-badge--active { background: rgba(34, 197, 94, 0.18); color: #86efac; border: 1px solid rgba(34, 197, 94, 0.28); }
+.status-badge--paused { background: rgba(234, 179, 8, 0.18); color: #facc15; border: 1px solid rgba(234, 179, 8, 0.28); }
 
 .recurring-plan-card .btn { min-height: 44px; }
-.recurring-plan-card .next-occurrence { font-weight: 600; color: #c4b5fd; }
+.recurring-plan-card .next-occurrence { font-weight: 600; color: var(--primary-color-light); }
 
 @media (min-width: 480px) {
     .day-picker-grid { grid-template-columns: repeat(7, minmax(0, 1fr)); }
 }
 
 /* Chat Page Styles */
-#page-chat .chat-bubble { max-width: 75%; padding: 0.75rem 1rem; border-radius: 1.25rem; }
-#page-chat .chat-bubble.user { background: var(--primary-color); color: white; border-bottom-right-radius: 0.25rem; }
-#page-chat .chat-bubble.walker { background: var(--glass-bg); border-bottom-left-radius: 0.25rem; }
+#page-chat .chat-bubble { max-width: 75%; padding: 0.8rem 1rem; border-radius: 1.4rem; box-shadow: rgba(8, 47, 73, 0.25) 0 10px 24px; }
+#page-chat .chat-bubble.user { background: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-color-light) 100%); color: var(--text-color-dark); border-bottom-right-radius: 0.5rem; }
+#page-chat .chat-bubble.walker { background: rgba(15, 23, 42, 0.55); border-bottom-left-radius: 0.5rem; border: 1px solid var(--surface-border); }
 
 /* Favorite Button */
-.favorite-btn { background: none; border: none; cursor: pointer; color: var(--text-color); transition: all 0.3s ease; }
-.favorite-btn.favorited { color: #F472B6; /* A nice pink */ }
+.favorite-btn { background: none; border: none; cursor: pointer; color: var(--text-color); transition: var(--transition-base); }
+.favorite-btn:hover { color: #fca5a5; }
+.favorite-btn.favorited { color: #fb7185; }
 .favorite-btn svg { stroke: currentColor; transition: fill 0.3s ease; }
 .favorite-btn.favorited svg { fill: currentColor; }
 
 /* Success Modal */
-.modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.6); backdrop-filter: blur(5px); display: flex; justify-content: center; align-items: center; opacity: 0; visibility: hidden; transition: all 0.3s ease-in-out; z-index: 100; }
+.modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(7, 11, 20, 0.65); backdrop-filter: blur(10px); display: flex; justify-content: center; align-items: center; opacity: 0; visibility: hidden; transition: all 0.3s ease-in-out; z-index: 100; }
 .modal-overlay.active { opacity: 1; visibility: visible; }
 .modal-content { text-align: center; padding: 2.5rem; transform: scale(0.8); transition: transform 0.3s ease-in-out; }
 .modal-overlay.active .modal-content { transform: scale(1); }
@@ -371,3 +477,47 @@ body::after {
 @keyframes stroke { 100% { stroke-dashoffset: 0; } }
 @keyframes scale { 0%, 100% { transform: none; } 50% { transform: scale3d(1.1, 1.1, 1); } }
 @keyframes fill { 100% { box-shadow: inset 0px 0px 0px 60px var(--primary-color); } }
+.card-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.avatar-frame {
+    border-radius: 1rem;
+    border: 1px solid var(--surface-border);
+    box-shadow: 0 12px 24px rgba(8, 47, 73, 0.25);
+}
+
+.profile-link {
+    color: var(--text-color);
+    transition: var(--transition-base);
+}
+
+.profile-link span:last-child {
+    color: var(--text-color-soft);
+}
+
+.profile-link:hover {
+    color: var(--primary-color-light);
+}
+
+.divider-soft {
+    height: 1px;
+    width: 100%;
+    background: linear-gradient(90deg, transparent, rgba(148, 163, 184, 0.35), transparent);
+}
+
+.badge-muted {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    background: rgba(148, 163, 184, 0.12);
+    color: var(--text-color-soft);
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -6,15 +6,15 @@ let dogData = [
     { id: 3, name: 'Max', avatar: '🐕', breed: 'German Shepherd', age: 2, notes: 'Very energetic! Needs a long run.', vet: 'Parkside Vet Clinic', allergies: 'None', likes: 'Frisbees', dislikes: 'Mail carriers' },
 ];
 const walkerData = [
-    { id: 1, name: 'Alex Ray', avatar: 'https://placehold.co/100x100/7F00FF/FFFFFF?text=A', verified: true, rating: 4.9, reviews: 124, price: 25, bio: "Hi, I'm Alex! I've been a passionate dog lover my whole life and have 5+ years of professional walking experience. I'm certified in Pet First Aid and can't wait to meet your furry friend!", badges: ["Pet CPR Certified", "5+ Years Exp."], favorite: true },
-    { id: 2, name: 'Jordan Lee', avatar: 'https://placehold.co/100x100/8A2BE2/FFFFFF?text=J', verified: true, rating: 4.8, reviews: 98, price: 24, bio: "Jordan is a marathon runner who loves taking high-energy dogs on long adventures. If your pup needs to burn off some steam, I'm your walker.", badges: ["Great with Large Dogs"], favorite: false },
-    { id: 3, name: 'Casey Smith', avatar: 'https://placehold.co/100x100/9370DB/FFFFFF?text=C', verified: false, rating: 4.7, reviews: 75, price: 22, bio: "As a veterinary student, I have a deep understanding of animal care and behavior. I'm especially good with shy or anxious dogs.", badges: ["Experience with Puppies"], favorite: true },
+    { id: 1, name: 'Alex Ray', avatar: 'https://placehold.co/100x100/0F766E/0B1120?text=A', verified: true, rating: 4.9, reviews: 124, price: 25, bio: "Hi, I'm Alex! I've been a passionate dog lover my whole life and have 5+ years of professional walking experience. I'm certified in Pet First Aid and can't wait to meet your furry friend!", badges: ["Pet CPR Certified", "5+ Years Exp."], favorite: true },
+    { id: 2, name: 'Jordan Lee', avatar: 'https://placehold.co/100x100/14B8A6/0B1120?text=J', verified: true, rating: 4.8, reviews: 98, price: 24, bio: "Jordan is a marathon runner who loves taking high-energy dogs on long adventures. If your pup needs to burn off some steam, I'm your walker.", badges: ["Great with Large Dogs"], favorite: false },
+    { id: 3, name: 'Casey Smith', avatar: 'https://placehold.co/100x100/0E7490/0B1120?text=C', verified: false, rating: 4.7, reviews: 75, price: 22, bio: "As a veterinary student, I have a deep understanding of animal care and behavior. I'm especially good with shy or anxious dogs.", badges: ["Experience with Puppies"], favorite: true },
 ];
 let walkHistoryData = [
     { id: 99, date: '2025-09-16', time: '16:00', duration: 30, walker: walkerData[1], dogs: [dogData[0]], price: 25.00, status: 'In Progress' },
-    { id: 1, date: '2025-09-11', walker: walkerData[1], dogs: [dogData[0]], price: 25.00, status: 'Completed', photos: ['https://placehold.co/300x200/5f3781/FFFFFF?text=Buddy+Playing', 'https://placehold.co/300x200/8A2BE2/FFFFFF?text=Happy+Pup'], activity: { pee: true, poo: true, water: true }, note: "Buddy had a great time at the park. Full of energy today!" },
+    { id: 1, date: '2025-09-11', walker: walkerData[1], dogs: [dogData[0]], price: 25.00, status: 'Completed', photos: ['https://placehold.co/300x200/0B1120/1DD3B0?text=Buddy+Playing', 'https://placehold.co/300x200/0F766E/0B1120?text=Happy+Pup'], activity: { pee: true, poo: true, water: true }, note: "Buddy had a great time at the park. Full of energy today!" },
     { id: 2, date: '2025-09-09', walker: walkerData[0], dogs: [dogData[0], dogData[1]], price: 40.00, status: 'Completed', photos: [], activity: { pee: true, poo: false, water: true }, note: "Lucy was a little shy but warmed up. Buddy was great as always." },
-    { id: 3, date: '2025-09-05', walker: walkerData[2], dogs: [dogData[2]], price: 22.00, status: 'Completed', photos: ['https://placehold.co/300x200/9370DB/FFFFFF?text=Max+Running'], activity: { pee: true, poo: true, water: false }, note: "Max loved the long run by the lake!" },
+    { id: 3, date: '2025-09-05', walker: walkerData[2], dogs: [dogData[2]], price: 22.00, status: 'Completed', photos: ['https://placehold.co/300x200/0E7490/0B1120?text=Max+Running'], activity: { pee: true, poo: true, water: false }, note: "Max loved the long run by the lake!" },
 ];
 
 let recurringWalkPlans = [
@@ -192,8 +192,8 @@ const fullBookingFlowHTML = `
             <div class="space-y-6 stagger-in">
                 <h2 class="text-lg font-semibold">Service</h2>
                 <div class="grid grid-cols-2 gap-4">
-                    <label class="checkable-card"><input type="radio" name="service" value="30" data-price="25" checked><div class="card-content glass-card p-4"><div class="text-2xl font-bold">30 min</div><div class="text-lg opacity-80">$25</div></div></label>
-                    <label class="checkable-card"><input type="radio" name="service" value="60" data-price="40"><div class="card-content glass-card p-4"><div class="text-2xl font-bold">60 min</div><div class="text-lg opacity-80">$40</div></div></label>
+                    <label class="checkable-card"><input type="radio" name="service" value="30" data-price="25" checked><div class="card-content glass-card p-4"><div class="text-2xl font-bold text-white">30 min</div><div class="text-lg text-soft">$25</div></div></label>
+                    <label class="checkable-card"><input type="radio" name="service" value="60" data-price="40"><div class="card-content glass-card p-4"><div class="text-2xl font-bold text-white">60 min</div><div class="text-lg text-soft">$40</div></div></label>
                 </div>
                 <div class="grid grid-cols-2 gap-4">
                     <div><h2 class="text-lg font-semibold mb-3">Date</h2><div class="input-group"><input type="date" id="walk-date" class="input-field"></div></div>
@@ -224,12 +224,12 @@ const fullBookingFlowHTML = `
             <div class="space-y-6 stagger-in">
                 <div class="glass-card p-5 space-y-3">
                     <h2 class="text-lg font-semibold">Walk Details</h2>
-                    <div id="summary-details" class="divide-y divide-[var(--glass-border)]"></div>
+                    <div id="summary-details" class="divide-y divide-[var(--surface-border)]"></div>
                 </div>
                 <div class="glass-card p-5 space-y-3">
                     <h2 class="text-lg font-semibold">Price Summary</h2>
-                    <div id="price-details" class="divide-y divide-[var(--glass-border)]"></div>
-                    <div class="flex justify-between items-center font-bold text-lg border-t border-[var(--glass-border)] pt-3 mt-3">
+                    <div id="price-details" class="divide-y divide-[var(--surface-border)]"></div>
+                    <div class="flex justify-between items-center font-bold text-lg border-t border-[var(--surface-border)] pt-3 mt-3">
                         <span>Total</span><span id="total-price"></span>
                     </div>
                 </div>
@@ -381,10 +381,10 @@ function renderDashboard() {
         const recentWalks = completedWalks.slice(0, 2);
         recentActivityList.innerHTML = recentWalks.map(walk => `
             <div class="glass-card p-3 flex items-center gap-3">
-                <img src="${walk.walker.avatar}" class="w-10 h-10 rounded-full" alt="${walk.walker.name}">
+                <img src="${walk.walker.avatar}" class="w-10 h-10 avatar-frame object-cover" alt="${walk.walker.name}">
                 <div>
                     <p class="font-semibold">Walk with ${walk.walker.name}</p>
-                    <p class="text-xs opacity-70">${new Date(walk.date + 'T00:00:00').toLocaleDateString()}</p>
+                    <p class="text-xs text-soft">${new Date(walk.date + 'T00:00:00').toLocaleDateString()}</p>
                 </div>
                 <span class="ml-auto font-bold text-sm">$${walk.price.toFixed(2)}</span>
             </div>`).join('');
@@ -396,8 +396,8 @@ function renderHistoryPage() {
     document.getElementById('history-list-container').innerHTML = walkHistoryData.map(walk => `
         <div class="glass-card p-4 cursor-pointer walk-history-item" data-walk-id="${walk.id}">
             <div class="flex justify-between items-center">
-                <div><p class="font-bold text-lg">${new Date(walk.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}</p><p class="text-sm opacity-80">With ${walk.walker.name}</p></div>
-                <div class="text-right"><p class="font-bold text-lg">$${walk.price.toFixed(2)}</p><p class="text-sm opacity-80">${walk.dogs.map(d => d.avatar).join(' ')}</p></div>
+                <div><p class="font-bold text-lg text-white">${new Date(walk.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}</p><p class="text-sm text-soft">With ${walk.walker.name}</p></div>
+                <div class="text-right"><p class="font-bold text-lg text-white">$${walk.price.toFixed(2)}</p><p class="text-sm text-soft">${walk.dogs.map(d => d.avatar).join(' ')}</p></div>
             </div>
         </div>`).join('');
 
@@ -422,10 +422,10 @@ function renderWalkSummary(walkId) {
         <div class="page-header"><button class="back-btn" data-target="page-history"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg></button><h1>Walk Summary</h1></div>
         <div class="space-y-6">
             <div class="glass-card overflow-hidden"><img src="https://placehold.co/600x300/3d1c5a/E0E0E0?text=Walk+Route+Map" alt="Map of walk route"></div>
-            <div class="glass-card p-4 flex items-center gap-4"><img src="${walk.walker.avatar}" class="w-16 h-16 rounded-full"><div><p class="opacity-80">Your walker was</p><p class="font-bold text-xl">${walk.walker.name}</p></div></div>
+            <div class="glass-card p-4 flex items-center gap-4"><img src="${walk.walker.avatar}" class="w-16 h-16 avatar-frame object-cover"><div><p class="text-soft">Your walker was</p><p class="font-bold text-xl text-white">${walk.walker.name}</p></div></div>
             ${(walk.photos && walk.photos.length > 0) ? `<div class="glass-card p-4"><h3 class="font-semibold mb-3">Photo Gallery</h3><div class="grid grid-cols-3 gap-2">${walk.photos.map(p => `<img src="${p}" class="rounded-lg w-full h-24 object-cover">`).join('')}</div></div>` : ''}
-            ${walk.activity ? `<div class="glass-card p-4"><h3 class="font-semibold mb-3">Activity Report</h3><div class="flex justify-around text-center">${['Pee', 'Poo', 'Water'].map(act => `<div><div class="w-12 h-12 rounded-full flex items-center justify-center mx-auto ${walk.activity[act.toLowerCase()] ? 'bg-green-500/50' : 'bg-red-500/50'}">${walk.activity[act.toLowerCase()] ? '✓' : '✗'}</div><p class="text-xs mt-1">${act}</p></div>`).join('')}</div></div>` : ''}
-            <div class="glass-card p-4"><h3 class="font-semibold mb-2">Walker's Note</h3><p class="opacity-80 italic">"${walk.note}"</p></div>
+            ${walk.activity ? `<div class="glass-card p-4"><h3 class="font-semibold mb-3">Activity Report</h3><div class="flex justify-around text-center">${['Pee', 'Poo', 'Water'].map(act => `<div><div class="w-12 h-12 rounded-full flex items-center justify-center mx-auto ${walk.activity[act.toLowerCase()] ? 'bg-emerald-500/40 text-emerald-200' : 'bg-rose-500/35 text-rose-200'}">${walk.activity[act.toLowerCase()] ? '✓' : '✗'}</div><p class="text-xs mt-2 text-soft uppercase tracking-wide">${act}</p></div>`).join('')}</div></div>` : ''}
+            <div class="glass-card p-4"><h3 class="font-semibold mb-2">Walker's Note</h3><p class="text-soft italic">"${walk.note}"</p></div>
         </div>`;
 }
 
@@ -433,7 +433,7 @@ function renderDogsPage() {
      document.getElementById('dog-list-container').innerHTML = dogData.map(dog => `
         <div class="glass-card p-4 flex items-center gap-4">
             <span class="text-5xl">${dog.avatar}</span>
-            <div class="flex-grow"><p class="font-bold text-lg">${dog.name}</p><p class="text-sm opacity-80">${dog.breed}, ${dog.age} years old</p></div>
+            <div class="flex-grow"><p class="font-bold text-lg text-white">${dog.name}</p><p class="text-sm text-soft">${dog.breed}, ${dog.age} years old</p></div>
             <button class="btn-secondary px-3 py-2 text-sm rounded-lg dog-edit-btn" data-dog-id="${dog.id}">Edit</button>
         </div>`).join('');
      document.querySelectorAll('.dog-edit-btn').forEach(btn => btn.addEventListener('click', e => goToPage('page-dog-form', { dogId: parseInt(e.currentTarget.dataset.dogId) })));
@@ -471,13 +471,13 @@ function renderInboxPage() {
         const walker = walkerData.find(w => w.id === convo.walkerId);
         return `
         <div class="glass-card p-4 flex items-center gap-4 cursor-pointer inbox-item" data-walker-id="${walker.id}">
-             <img src="${walker.avatar}" class="w-14 h-14 rounded-full">
+             <img src="${walker.avatar}" class="w-14 h-14 avatar-frame object-cover">
              <div class="flex-grow">
                 <div class="flex justify-between items-start">
                      <p class="font-bold text-lg">${walker.name}</p>
-                     ${convo.unread ? `<span class="w-3 h-3 bg-blue-500 rounded-full mt-1"></span>` : ''}
+                     ${convo.unread ? `<span class="w-3 h-3 bg-teal-300 rounded-full mt-1"></span>` : ''}
                 </div>
-                <p class="text-sm opacity-80 truncate">${convo.lastMessage}</p>
+                <p class="text-sm text-soft truncate">${convo.lastMessage}</p>
              </div>
         </div>`
     }).join('');
@@ -508,10 +508,10 @@ function renderWalkerProfile(walkerId, backTarget = 'page-home') {
             <button class="favorite-btn p-2 ${walker.favorite ? 'favorited' : ''}" data-walker-id="${walker.id}"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg></button>
         </div>
         <div class="space-y-6 stagger-in">
-            <div class="flex flex-col items-center"><img src="${walker.avatar}" class="w-28 h-28 rounded-full border-4 border-[var(--glass-border)]"><h2 class="text-2xl font-bold mt-4">${walker.name}</h2><p class="opacity-70">★ ${walker.rating} (${walker.reviews} Reviews)</p></div>
-            <div class="flex justify-center gap-2">${walker.badges.map(b => `<span class="bg-[var(--glass-bg)] text-xs font-semibold px-3 py-1 rounded-full">${b}</span>`).join('')}</div>
-            <div class="glass-card p-5"><h3 class="font-semibold mb-2">About Me</h3><p class="opacity-80">${walker.bio}</p></div>
-            <div class="glass-card p-5"><h3 class="font-semibold mb-2">Reviews</h3><div class="space-y-3"><div class="flex gap-2"><p class="font-bold">Anna K.</p><p>★★★★★</p></div><p class="opacity-80 text-sm italic">"Alex was amazing with my energetic puppy!"</p></div></div>
+            <div class="flex flex-col items-center"><img src="${walker.avatar}" class="w-28 h-28 avatar-frame object-cover border border-[var(--surface-border)]"><h2 class="text-2xl font-bold mt-4">${walker.name}</h2><p class="text-soft">★ ${walker.rating} (${walker.reviews} Reviews)</p></div>
+            <div class="flex justify-center gap-2 flex-wrap">${walker.badges.map(b => `<span class="badge-muted">${b}</span>`).join('')}</div>
+            <div class="glass-card p-5"><h3 class="font-semibold mb-2">About Me</h3><p class="text-soft">${walker.bio}</p></div>
+            <div class="glass-card p-5"><h3 class="font-semibold mb-2">Reviews</h3><div class="space-y-3"><div class="flex gap-2 items-center text-soft"><p class="font-bold text-white">Anna K.</p><p>★★★★★</p></div><p class="text-sm italic text-soft">"Alex was amazing with my energetic puppy!"</p></div></div>
         </div>`;
 
     container.querySelector('.favorite-btn').addEventListener('click', e => {
@@ -532,7 +532,7 @@ function renderLiveTracking(walkId) {
         <div class="space-y-4">
              <div class="glass-card non-hover overflow-hidden h-64 flex items-center justify-center"><img src="https://placehold.co/600x400/3d1c5a/E0E0E0?text=Live+Map" alt="Live Map" class="w-full h-full object-cover"></div>
              <div class="glass-card non-hover p-4 text-center"><p class="text-lg">Time Remaining</p><p class="text-4xl font-bold">21:47</p></div>
-             <div class="glass-card non-hover p-4"><div class="flex items-center gap-4"><img src="${walk.walker.avatar}" class="w-12 h-12 rounded-full"><p class="font-semibold">${walk.walker.name} is walking ${walk.dogs.map(d=>d.name).join(', ')}</p></div></div>
+            <div class="glass-card non-hover p-4"><div class="flex items-center gap-4"><img src="${walk.walker.avatar}" class="w-12 h-12 avatar-frame object-cover"><p class="font-semibold">${walk.walker.name} is walking ${walk.dogs.map(d=>d.name).join(', ')}</p></div></div>
              <div class="glass-card non-hover p-4"><h3 class="font-semibold mb-2">Send a Message</h3><div class="input-group"><input type="text" placeholder="Great job!" class="input-field pr-20"><button class="absolute right-2 btn btn-primary py-2 px-3 text-sm">Send</button></div></div>
         </div>`;
 }
@@ -552,7 +552,7 @@ function renderRecurringWalksPage() {
             <div id="recurring-empty-state" class="glass-card p-5 text-center space-y-2 ${recurringWalkPlans.length ? 'hidden' : ''}">
                 <div class="text-4xl">🗓️</div>
                 <h2 class="text-lg font-semibold">No recurring walks yet</h2>
-                <p class="text-sm opacity-80">Create a schedule so your pups never miss their favorite stroll.</p>
+                <p class="text-sm text-soft">Create a schedule so your pups never miss their favorite stroll.</p>
             </div>
             <div id="recurring-plan-list" class="space-y-4"></div>
             <button class="btn btn-primary w-full" id="recurring-schedule-btn">Set Up New Schedule</button>
@@ -561,7 +561,7 @@ function renderRecurringWalksPage() {
                     <div class="flex justify-between items-center">
                         <div>
                             <h2 class="text-lg font-semibold" id="recurring-form-title">Set Up New Schedule</h2>
-                            <p class="text-sm opacity-70" id="recurring-form-subtitle">Pick the routine that fits your pups best.</p>
+                            <p class="text-sm text-soft" id="recurring-form-subtitle">Pick the routine that fits your pups best.</p>
                         </div>
                         <button type="button" class="icon-button" id="recurring-form-close" aria-label="Close schedule form">
                             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
@@ -569,7 +569,7 @@ function renderRecurringWalksPage() {
                     </div>
                     <div class="space-y-4">
                         <div>
-                            <h3 class="text-sm font-semibold mb-2">Plan nickname <span class="opacity-60">(optional)</span></h3>
+                            <h3 class="text-sm font-semibold mb-2 text-white">Plan nickname <span class="text-soft">(optional)</span></h3>
                             <div class="input-group"><input type="text" id="recurring-plan-label" class="input-field" placeholder="e.g., Morning crew"></div>
                         </div>
                         <div>
@@ -700,7 +700,7 @@ function renderRecurringWalksPage() {
                 <input type="radio" name="recurring-duration" value="${option.value}" ${option.value === selectedDuration ? 'checked' : ''}>
                 <div class="card-content glass-card p-4">
                     <div class="text-lg font-semibold">${option.label}</div>
-                    <div class="text-sm opacity-70">${option.price}</div>
+                    <div class="text-sm text-soft">${option.price}</div>
                 </div>
                 <div class="checkmark"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg></div>
             </label>
@@ -710,7 +710,7 @@ function renderRecurringWalksPage() {
     function renderWalkerOptions(walkers, selectedId = null) {
         if (!walkerListEl) return;
         if (!walkers.length) {
-            walkerListEl.innerHTML = '<p class="text-sm opacity-70 text-center">No walkers match your filters.</p>';
+            walkerListEl.innerHTML = '<p class="text-sm text-soft text-center">No walkers match your filters.</p>';
             return;
         }
         walkerListEl.innerHTML = walkers.map(walker => {
@@ -718,13 +718,13 @@ function renderRecurringWalksPage() {
             return `
             <label class="walker-option glass-card p-4 flex items-center gap-3${isSelected ? ' selected' : ''}">
                 <input type="radio" class="hidden" name="recurring-walker" value="${walker.id}" ${isSelected ? 'checked' : ''}>
-                <img src="${walker.avatar}" alt="${walker.name}" class="w-12 h-12 rounded-full object-cover">
+                <img src="${walker.avatar}" alt="${walker.name}" class="w-12 h-12 avatar-frame object-cover">
                 <div class="flex-1">
                     <div class="flex items-center gap-2">
                         <span class="font-semibold">${walker.name}</span>
-                        ${walker.verified ? '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="#60a5fa" stroke="white" stroke-width="1"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>' : ''}
+                        ${walker.verified ? '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="#5eead4" stroke="#0b1120" stroke-width="1"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>' : ''}
                     </div>
-                    <p class="text-xs opacity-70">★ ${walker.rating.toFixed(1)} • $${walker.price.toFixed(0)}</p>
+                    <p class="text-xs text-soft">★ ${walker.rating.toFixed(1)} • $${walker.price.toFixed(0)}</p>
                 </div>
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="selection-indicator"><polyline points="20 6 9 17 4 12"></polyline></svg>
             </label>
@@ -795,11 +795,11 @@ function renderRecurringWalksPage() {
                     <div class="flex justify-between gap-3 items-start">
                         <div>
                             <p class="font-semibold text-base">${plan.label || formatPlanDays(plan.daysOfWeek)}</p>
-                            <p class="text-sm opacity-70">${subtitle}</p>
+                            <p class="text-sm text-soft">${subtitle}</p>
                         </div>
                         <span class="status-badge ${statusClass}">${statusLabel}</span>
                     </div>
-                    <div class="text-sm opacity-80 space-y-1">
+                    <div class="text-sm text-soft space-y-1">
                         <p>${formatPlanDays(plan.daysOfWeek)} • ${formatTimeDisplay(plan.time)} • ${plan.duration} min</p>
                         <p>Walker: ${walker ? walker.name : 'Select during booking'}</p>
                         <p>Dogs: ${dogs || 'Select dogs'}</p>
@@ -954,12 +954,12 @@ function renderRecurringWalksPage() {
 
 function renderPaymentsPage() {
     const container = document.getElementById('page-payments');
-    container.innerHTML = `<div class="page-header"><button class="back-btn" data-target="page-profile"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg></button><h1>Payments</h1></div><div class="space-y-6"><div class="glass-card p-5"><h3 class="font-semibold mb-3">My Card</h3><div class="flex items-center gap-4"><img src="https://placehold.co/60x40/FFFFFF/000000?text=VISA" class="w-12 rounded-md"><p>**** **** **** ${paymentData.card.last4}</p><p class="ml-auto text-sm opacity-80">Exp ${paymentData.card.expiry}</p></div></div><div class="glass-card p-5"><h3 class="font-semibold mb-3">Transaction History</h3><div class="space-y-2">${paymentData.transactions.map(t => `<div class="flex justify-between text-sm"><p>${t.desc}</p><p>$${t.amount.toFixed(2)}</p></div>`).join('')}</div></div><button class="btn btn-secondary w-full">Add New Card</button></div>`;
+    container.innerHTML = `<div class="page-header"><button class="back-btn" data-target="page-profile"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg></button><h1>Payments</h1></div><div class="space-y-6"><div class="glass-card p-5"><h3 class="font-semibold mb-3">My Card</h3><div class="flex items-center gap-4"><img src="https://placehold.co/60x40/FFFFFF/0B1120?text=VISA" class="w-12 rounded-md border border-[var(--surface-border)]"><p class="text-white">**** **** **** ${paymentData.card.last4}</p><p class="ml-auto text-sm text-soft">Exp ${paymentData.card.expiry}</p></div></div><div class="glass-card p-5"><h3 class="font-semibold mb-3">Transaction History</h3><div class="space-y-2">${paymentData.transactions.map(t => `<div class="flex justify-between text-sm text-soft"><p>${t.desc}</p><p>$${t.amount.toFixed(2)}</p></div>`).join('')}</div></div><button class="btn btn-secondary w-full">Add New Card</button></div>`;
 }
 
 function renderPromotionsPage() {
      const container = document.getElementById('page-promotions');
-     container.innerHTML = `<div class="page-header"><button class="back-btn" data-target="page-profile"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg></button><h1>Promotions</h1></div><div class="space-y-6"><div class="glass-card p-5 text-center"><h3 class="font-semibold mb-2">Refer a Friend, Get $10!</h3><p class="opacity-80 text-sm mb-4">Share your code and you'll both get $10 off your next walk.</p><div class="p-3 bg-black/20 rounded-lg font-mono tracking-widest">ALEX-WALKS-25</div></div><div class="glass-card p-5"><h3 class="font-semibold mb-3">Active Promos</h3><div class="p-3 bg-primary-color/20 rounded-lg"><p class="font-bold">15% Off All 60-Min Walks</p><p class="text-sm opacity-80">Valid this weekend only. Auto-applied at checkout.</p></div></div></div>`;
+     container.innerHTML = `<div class="page-header"><button class="back-btn" data-target="page-profile"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg></button><h1>Promotions</h1></div><div class="space-y-6"><div class="glass-card p-5 text-center space-y-3"><h3 class="font-semibold text-white">Refer a Friend, Get $10!</h3><p class="text-soft text-sm">Share your code and you'll both get $10 off your next walk.</p><div class="p-3 rounded-lg font-mono tracking-widest border border-[var(--surface-border)] bg-[rgba(15,23,42,0.6)]">ALEX-WALKS-25</div></div><div class="glass-card p-5 space-y-3"><h3 class="font-semibold text-white">Active Promos</h3><div class="p-3 rounded-lg border border-[var(--surface-border)] bg-[rgba(20,184,166,0.15)]"><p class="font-bold text-white">15% Off All 60-Min Walks</p><p class="text-sm text-soft">Valid this weekend only. Auto-applied at checkout.</p></div></div></div>`;
 }
 
 function fullInitBookingFlow() {
@@ -986,7 +986,7 @@ function fullInitBookingFlow() {
 
     function showSuccessModal() {
         vibrate(50);
-        const modalHTML = `<div class="modal-overlay active" id="successModal"><div class="modal-content glass-card"><svg class="success-checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 52"><circle class="checkmark-circle" cx="26" cy="26" r="25" fill="none"/><path class="checkmark-check" fill="none" d="M14.1 27.2l7.1 7.2 16.7-16.8"/></svg><h2 class="text-2xl font-bold mb-2">Booking Confirmed!</h2><p class="opacity-80">Your dog's adventure is scheduled.</p><button id="modal-back-to-home" class="btn btn-primary mt-4 w-full">Back to Home</button></div></div>`;
+        const modalHTML = `<div class="modal-overlay active" id="successModal"><div class="modal-content glass-card"><svg class="success-checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 52"><circle class="checkmark-circle" cx="26" cy="26" r="25" fill="none"/><path class="checkmark-check" fill="none" d="M14.1 27.2l7.1 7.2 16.7-16.8"/></svg><h2 class="text-2xl font-bold mb-2 text-white">Booking Confirmed!</h2><p class="text-soft">Your dog's adventure is scheduled.</p><button id="modal-back-to-home" class="btn btn-primary mt-4 w-full">Back to Home</button></div></div>`;
         document.body.insertAdjacentHTML('beforeend', modalHTML);
         document.getElementById('modal-back-to-home').addEventListener('click', () => {
             document.getElementById('successModal').remove();
@@ -1040,18 +1040,18 @@ function fullInitBookingFlow() {
     function renderWalkerList(walkers) {
         document.getElementById('toScreen3Btn').disabled = true;
         const walkerList = document.getElementById('walker-list');
-        walkerList.innerHTML = Array(3).fill('').map(() => `<div class="glass-card p-4 flex gap-4 items-center animate-pulse"><div class="w-16 h-16 rounded-full bg-[var(--glass-border)]"></div><div class="flex-1 space-y-2"><div class="h-4 w-3/4 rounded bg-[var(--glass-border)]"></div><div class="h-3 w-1/2 rounded bg-[var(--glass-border)]"></div></div></div>`).join('');
+        walkerList.innerHTML = Array(3).fill('').map(() => `<div class="glass-card p-4 flex gap-4 items-center animate-pulse"><div class="w-16 h-16 rounded-full bg-[var(--surface-border)]"></div><div class="flex-1 space-y-2"><div class="h-4 w-3/4 rounded bg-[var(--surface-border)]"></div><div class="h-3 w-1/2 rounded bg-[var(--surface-border)]"></div></div></div>`).join('');
 
         setTimeout(() => {
             if (walkers.length === 0) {
-                 walkerList.innerHTML = `<p class="text-center opacity-80">No walkers match your criteria.</p>`;
+                 walkerList.innerHTML = `<p class="text-center text-soft">No walkers match your criteria.</p>`;
                  return;
             }
-            walkerList.innerHTML = walkers.map(w => `<div class="walker-card-container relative"><input type="radio" name="walker" value="${w.id}" class="hidden" id="walker-radio-${w.id}"><label for="walker-radio-${w.id}" class="glass-card p-4 flex gap-4 items-center cursor-pointer"><img src="${w.avatar}" alt="${w.name}" class="w-16 h-16 rounded-full view-profile-btn" data-walker-id="${w.id}"><div class="flex-1"> <div class="flex items-center gap-2"><h3 class="font-bold text-lg">${w.name}</h3>${w.verified ? `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="#3b82f6" stroke="white" stroke-width="1"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>`:''}</div><p class="text-sm opacity-80">★ ${w.rating.toFixed(1)} (${w.reviews} reviews)</p></div><div class="text-right"><p class="text-xl font-bold">$${w.price.toFixed(2)}</p></div></label><button class="favorite-btn absolute top-3 right-3 p-2 ${w.favorite ? 'favorited' : ''}" data-walker-id="${w.id}"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg></button></div>`).join('');
+            walkerList.innerHTML = walkers.map(w => `<div class="walker-card-container relative"><input type="radio" name="walker" value="${w.id}" class="hidden" id="walker-radio-${w.id}"><label for="walker-radio-${w.id}" class="glass-card p-4 flex gap-4 items-center cursor-pointer"><img src="${w.avatar}" alt="${w.name}" class="w-16 h-16 avatar-frame view-profile-btn object-cover" data-walker-id="${w.id}"><div class="flex-1"> <div class="flex items-center gap-2"><h3 class="font-bold text-lg text-white">${w.name}</h3>${w.verified ? `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="#5eead4" stroke="#0b1120" stroke-width="1"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>`:''}</div><p class="text-sm text-soft">★ ${w.rating.toFixed(1)} (${w.reviews} reviews)</p></div><div class="text-right"><p class="text-xl font-bold text-white">$${w.price.toFixed(2)}</p></div></label><button class="favorite-btn absolute top-3 right-3 p-2 ${w.favorite ? 'favorited' : ''}" data-walker-id="${w.id}"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg></button></div>`).join('');
             walkerList.querySelectorAll('input[name="walker"]').forEach(radio => radio.addEventListener('change', e => {
                 bookingState.selectedWalker = walkerData.find(w => w.id === parseInt(e.target.value));
                 document.getElementById('toScreen3Btn').disabled = false;
-                walkerList.querySelectorAll('.glass-card').forEach(c => c.style.borderColor = 'var(--glass-border)');
+                walkerList.querySelectorAll('.glass-card').forEach(c => c.style.borderColor = 'var(--surface-border)');
                 e.target.nextElementSibling.style.borderColor = 'var(--primary-color-light)';
             }));
             if (prefill?.walkerId && !hasAppliedPrefillWalker) {

--- a/index.html
+++ b/index.html
@@ -21,22 +21,23 @@
                 <!-- ===== PAGE: HOME/DASHBOARD ===== -->
                 <section class="page" id="page-home">
                     <div class="space-y-8 stagger-in">
-                        <div class="text-center pt-4">
-                            <h1 class="text-3xl font-bold">Hello, Alex!</h1>
-                            <p class="opacity-80">Ready for a new adventure? 🐾</p>
+                        <div class="pt-4 space-y-2">
+                            <span class="eyebrow block">Today</span>
+                            <h1 class="hero-title">Hello, Alex!</h1>
+                            <p class="text-soft">Ready for a new adventure? 🐾</p>
                         </div>
-                        
-                        <div id="upcoming-walk-section">
-                            <h2 class="text-lg font-semibold mb-3">Upcoming Walk</h2>
-                            <div id="upcoming-walk-card" class="glass-card p-4 flex items-center gap-4 cursor-pointer" data-walk-id="99">
-                                <img id="upcoming-walk-avatar" src="https://placehold.co/100x100/7F00FF/FFFFFF?text=J" alt="Jordan Lee" class="w-12 h-12 rounded-full">
-                                <div>
-                                    <p class="font-semibold" id="upcoming-walk-title">With Jordan Lee</p>
-                                    <p class="text-sm opacity-80" id="upcoming-walk-time">Today at 4:00 PM</p>
+
+                        <div id="upcoming-walk-section" class="space-y-3">
+                            <h2 class="section-title">Upcoming Walk</h2>
+                            <div id="upcoming-walk-card" class="glass-card card-row p-4 cursor-pointer" data-walk-id="99">
+                                <img id="upcoming-walk-avatar" src="https://placehold.co/96x96/0F766E/0B1120?text=J" alt="Jordan Lee" class="w-14 h-14 avatar-frame object-cover">
+                                <div class="space-y-1">
+                                    <p class="font-semibold text-base" id="upcoming-walk-title">With Jordan Lee</p>
+                                    <p class="text-sm text-soft" id="upcoming-walk-time">Today at 4:00 PM</p>
                                 </div>
-                                <div class="ml-auto text-right">
-                                    <p class="font-bold" id="upcoming-walk-duration">30 min</p>
-                                    <p class="text-sm opacity-80" id="upcoming-walk-dogs">🐶 Buddy</p>
+                                <div class="ml-auto text-right space-y-1">
+                                    <span class="badge-muted" id="upcoming-walk-duration">30 min</span>
+                                    <p class="text-sm text-soft" id="upcoming-walk-dogs">🐶 Buddy</p>
                                 </div>
                             </div>
                         </div>
@@ -47,7 +48,7 @@
                         </div>
 
                         <div>
-                             <h2 class="text-lg font-semibold mb-3">Recent Activity</h2>
+                             <h2 class="section-title">Recent Activity</h2>
                              <div class="space-y-3" id="recent-activity-list"></div>
                         </div>
 
@@ -97,11 +98,11 @@
                     <div class="page-header"><div class="placeholder"></div><h1>My Profile</h1></div>
                     <div class="space-y-6">
                         <div class="flex flex-col items-center">
-                            <img src="https://placehold.co/150x150/9370DB/FFFFFF?text=A" class="w-24 h-24 rounded-full border-4 border-[var(--glass-border)]">
+                            <img src="https://placehold.co/160x160/0B1120/1DD3B0?text=A" class="w-24 h-24 avatar-frame object-cover">
                             <h2 class="text-2xl font-bold mt-4">Alex Morgan</h2>
-                            <p class="opacity-70">alex.morgan@email.com</p>
+                            <p class="text-soft">alex.morgan@email.com</p>
                         </div>
-                        <div class="glass-card p-4 divide-y divide-[var(--glass-border)]">
+                        <div class="glass-card p-4 divide-y divide-[var(--surface-border)]">
                             <a href="#" class="profile-link py-3 flex justify-between items-center"><span>Edit Profile</span><span>></span></a>
                             <a href="#" class="profile-link py-3 flex justify-between items-center" data-target="page-payments"><span>Payment Methods</span><span>></span></a>
                             <a href="#" class="profile-link py-3 flex justify-between items-center" data-target="page-promotions"><span>Promotions & Referrals</span><span>></span></a>
@@ -142,42 +143,34 @@
         <!-- BOTTOM NAVIGATION BAR -->
         <nav class="bottom-nav">
             <button class="nav-item active" data-target="page-home">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-                <span>Home</span>
+                <span class="nav-item-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 10.5 12 3l9 7.5V21a1 1 0 0 1-1 1h-5v-6h-6v6H4a1 1 0 0 1-1-1z"/></svg>
+                </span>
+                <span class="nav-label">Home</span>
             </button>
             <button class="nav-item" data-target="page-inbox">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719" />
-                </svg>
-                <span>Messages</span>
+                <span class="nav-item-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.5 8.5 0 0 1 8 8Z"/></svg>
+                </span>
+                <span class="nav-label">Messages</span>
             </button>
             <button class="nav-item nav-item-primary" data-target="page-booking-flow" aria-label="Book a walk">
                 <span class="nav-item-icon">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <circle cx="12" cy="15.5" r="3.5"></circle>
-                        <circle cx="17.5" cy="9" r="1.8"></circle>
-                        <circle cx="6.5" cy="9" r="1.8"></circle>
-                        <circle cx="5" cy="15.5" r="1.5"></circle>
-                        <circle cx="19" cy="15.5" r="1.5"></circle>
-                        <line x1="12" y1="4" x2="12" y2="8"></line>
-                        <line x1="10" y1="6" x2="14" y2="6"></line>
-                    </svg>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11.8 11.8 7 7m7.8 4.8 4.8 4.8"/><path d="M7 17s-1.5-1.5 0-3l2-2 3 3-2 2c-1.5 1.5-3 0-3 0Z"/><path d="M17 7s1.5 1.5 0 3l-2 2-3-3 2-2c1.5-1.5 3 0 3 0Z"/><path d="M10.5 10.5 13.5 13.5"/></svg>
                 </span>
-                <span>Book Walk</span>
+                <span class="nav-label">Book Walk</span>
             </button>
             <button class="nav-item" data-target="page-dogs">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M11.25 16.25h1.5L12 17z" />
-                    <path d="M16 14v.5" />
-                    <path d="M4.42 11.247A13.152 13.152 0 0 0 4 14.556C4 18.728 7.582 21 12 21s8-2.272 8-6.444a11.702 11.702 0 0 0-.493-3.309" />
-                    <path d="M8 14v.5" />
-                    <path d="M8.5 8.5c-.384 1.05-1.083 2.028-2.344 2.5-1.931.722-3.576-.297-3.656-1-.113-.994 1.177-6.53 4-7 1.923-.321 3.651.845 3.651 2.235A7.497 7.497 0 0 1 14 5.277c0-1.39 1.844-2.598 3.767-2.277 2.823.47 4.113 6.006 4 7-.08.703-1.725 1.722-3.656 1-1.261-.472-1.855-1.45-2.239-2.5" />
-                </svg>
-                <span>Dogs</span>
+                <span class="nav-item-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7v6a8 8 0 0 0 16 0V7"/><path d="M9 11c0 .94-.78 1.7-1.75 1.7S5.5 11.94 5.5 11V7.5c0-.83.67-1.5 1.5-1.5s2 .67 2 1.5zm10 0c0 .94-.78 1.7-1.75 1.7S15.5 11.94 15.5 11V7.5c0-.83.67-1.5 1.5-1.5s2 .67 2 1.5z"/><path d="M11 15h2"/></svg>
+                </span>
+                <span class="nav-label">Dogs</span>
             </button>
             <button class="nav-item" data-target="page-profile">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
-                <span>Profile</span>
+                <span class="nav-item-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5Z"/><path d="M20 21a8 8 0 0 0-16 0"/></svg>
+                </span>
+                <span class="nav-label">Profile</span>
             </button>
         </nav>
     </div>


### PR DESCRIPTION
## Summary
- update the global design tokens to a charcoal + teal palette and adjust typography, spacing, and glass treatments to match
- refresh navigation, buttons, cards, and chat surfaces for softer elevation, consistent focus states, and calmer motion accents
- align avatars, inline icons, and dynamic markup with the new aesthetic across home, booking, profile, and recurring walk flows

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dbf7e1b96c832fa1e91ca16cc9faee