### PR TITLE
Update Book Walk navigation icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,13 @@
             </button>
             <button class="nav-item nav-item-primary" data-target="page-booking-flow" aria-label="Book a walk">
                 <span class="nav-item-icon">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11.8 11.8 7 7m7.8 4.8 4.8 4.8"/><path d="M7 17s-1.5-1.5 0-3l2-2 3 3-2 2c-1.5 1.5-3 0-3 0Z"/><path d="M17 7s1.5 1.5 0 3l-2 2-3-3 2-2c1.5-1.5 3 0 3 0Z"/><path d="M10.5 10.5 13.5 13.5"/></svg>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 26 26" fill="none">
+                        <path fill="currentColor" d="M13 13.6c-3.46 0-6.28 2.58-6.28 5.7 0 2.35 2.03 4.17 6.28 4.17s6.28-1.82 6.28-4.17c0-3.12-2.82-5.7-6.28-5.7Z"/>
+                        <circle cx="7.6" cy="10.3" r="2.35" fill="currentColor"/>
+                        <circle cx="11" cy="6.9" r="2.1" fill="currentColor"/>
+                        <circle cx="15" cy="6.9" r="2.1" fill="currentColor"/>
+                        <circle cx="18.4" cy="10.3" r="2.35" fill="currentColor"/>
+                    </svg>
                 </span>
                 <span class="nav-label">Book Walk</span>
             </button>


### PR DESCRIPTION
## Summary
- replace the Book Walk navigation button icon with a paw-print glyph that matches the app theme
- ensure the icon uses a 26x26 viewBox and currentColor fills so it responds to existing hover and focus styles

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68dc09585e0c832fa3a66d3e29e91d45