### PR TITLE
Update dogs nav icon to paw print

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,13 @@
             </button>
             <button class="nav-item" data-target="page-dogs">
                 <span class="nav-item-icon">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7v6a8 8 0 0 0 16 0V7"/><path d="M9 11c0 .94-.78 1.7-1.75 1.7S5.5 11.94 5.5 11V7.5c0-.83.67-1.5 1.5-1.5s2 .67 2 1.5zm10 0c0 .94-.78 1.7-1.75 1.7S15.5 11.94 15.5 11V7.5c0-.83.67-1.5 1.5-1.5s2 .67 2 1.5z"/><path d="M11 15h2"/></svg>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                        <path fill="currentColor" d="M12 12.2c-3.24 0-5.9 2.4-5.9 5.23 0 1.97 1.64 3.57 5.9 3.57s5.9-1.6 5.9-3.57c0-2.83-2.66-5.23-5.9-5.23Z"/>
+                        <circle cx="7.4" cy="9.2" r="2" fill="currentColor"/>
+                        <circle cx="16.6" cy="9.2" r="2" fill="currentColor"/>
+                        <circle cx="10" cy="6.1" r="1.8" fill="currentColor"/>
+                        <circle cx="14" cy="6.1" r="1.8" fill="currentColor"/>
+                    </svg>
                 </span>
                 <span class="nav-label">Dogs</span>
             </button>


### PR DESCRIPTION
## Summary
- replace the Dogs tab bottom navigation icon with a filled paw-print glyph sized for the existing 24px grid
- ensure the new SVG uses currentColor so hover and active states continue to pick up theme colors

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68dc0a80f874832fb3098d1c46190c62