### PR TITLE
Add helper caption to primary nav button

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -339,32 +339,49 @@ body::after {
 }
 
 .nav-item-primary {
+    flex: 0 0 auto;
+    align-self: center;
+    margin-top: -2rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.45rem;
+    color: var(--text-color);
+    text-align: center;
+}
+.nav-item-primary .nav-item-icon {
     background: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-color-light) 100%);
     color: var(--text-color-dark);
-    flex: 0 0 auto;
     width: 64px;
     height: 64px;
     border-radius: 50%;
-    align-self: center;
-    margin-top: -2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     box-shadow: 0 18px 38px rgba(29, 211, 176, 0.32);
     border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: var(--transition-base);
 }
 .nav-item-primary svg {
     width: 26px;
     height: 26px;
     color: inherit;
 }
-.nav-item-primary:hover,
-.nav-item-primary:focus-visible {
+.nav-item-primary:hover .nav-item-icon {
     transform: translateY(-3px);
     box-shadow: 0 22px 48px rgba(94, 234, 212, 0.35);
 }
 .nav-item-primary:focus-visible {
     outline: none;
+    box-shadow: none;
 }
-.nav-item-primary:active {
+.nav-item-primary:focus-visible .nav-item-icon {
+    transform: translateY(-3px);
+    box-shadow: 0 22px 48px rgba(94, 234, 212, 0.35), var(--focus-ring);
+}
+.nav-item-primary:active .nav-item-icon {
     transform: translateY(0);
+    box-shadow: 0 18px 38px rgba(29, 211, 176, 0.32);
 }
 .nav-item-primary .nav-label {
     position: absolute;
@@ -376,6 +393,13 @@ body::after {
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
+}
+.nav-caption {
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--text-color);
+    line-height: 1.2;
 }
 
 /* Staggered Animation */

--- a/index.html
+++ b/index.html
@@ -165,6 +165,7 @@
                     </svg>
                 </span>
                 <span class="nav-label">Book Walk</span>
+                <span class="nav-caption">Plan a walk</span>
             </button>
             <button class="nav-item" data-target="page-dogs">
                 <span class="nav-item-icon">


### PR DESCRIPTION
## Summary
- add a visible helper caption to the primary bottom-nav action while keeping the existing accessible label
- update primary navigation styles so the circular button and new caption stack cleanly with focus treatment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc0c3abfe8832fab96cc04d8869e0b