### PR TITLE
Add payment method form to payments page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -557,6 +557,58 @@ body::after {
     gap: 1rem;
 }
 
+.payment-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1rem;
+    border-radius: var(--border-radius);
+    background: rgba(15, 23, 42, 0.45);
+    border: 1px solid var(--surface-border);
+    transition: var(--transition-base);
+}
+
+.payment-card:hover {
+    border-color: var(--surface-border-strong);
+    box-shadow: 0 18px 36px rgba(8, 47, 73, 0.35);
+}
+
+.payment-card-brand {
+    width: 64px;
+    height: 40px;
+    border-radius: 0.85rem;
+    border: 1px solid var(--surface-border);
+    object-fit: cover;
+    background: rgba(15, 23, 42, 0.45);
+}
+
+.payment-card-meta {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.payment-card-address {
+    color: var(--text-color-soft);
+    line-height: 1.4;
+}
+
+.payment-card-address span {
+    display: block;
+}
+
+.payment-card-default {
+    border-color: var(--primary-color-light);
+    box-shadow: 0 18px 40px rgba(29, 211, 176, 0.22);
+}
+
+.payment-card-default .badge-muted {
+    background: rgba(29, 211, 176, 0.18);
+    border-color: rgba(29, 211, 176, 0.35);
+    color: var(--primary-color-light);
+}
+
 .avatar-frame {
     border-radius: 1rem;
     border: 1px solid var(--surface-border);
@@ -574,6 +626,51 @@ body::after {
 
 .profile-link:hover {
     color: var(--primary-color-light);
+}
+
+.profile-progress {
+    height: 10px;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.22);
+    overflow: hidden;
+    position: relative;
+}
+
+.profile-progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--primary-color), var(--primary-color-light));
+    transition: width 0.4s ease;
+}
+
+.profile-task-list li::marker {
+    color: var(--primary-color-light);
+}
+
+.app-toast {
+    position: fixed;
+    left: 50%;
+    bottom: 6rem;
+    transform: translateX(-50%) translateY(20px);
+    background: var(--surface-bg-strong);
+    color: var(--text-color);
+    padding: 0.85rem 1.3rem;
+    border-radius: 999px;
+    border: 1px solid var(--surface-border-strong);
+    box-shadow: var(--shadow-light);
+    opacity: 0;
+    pointer-events: none;
+    transition: all 0.3s ease;
+    z-index: 120;
+    font-weight: 500;
+}
+
+.app-toast.visible {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
 }
 
 .divider-soft {

--- a/index.html
+++ b/index.html
@@ -90,19 +90,17 @@
                 <!-- ===== PAGE: PROFILE ===== -->
                 <section class="page" id="page-profile">
                     <div class="page-header"><div class="placeholder"></div><h1>My Profile</h1></div>
-                    <div class="space-y-6">
-                        <div class="flex flex-col items-center">
-                            <img src="https://placehold.co/160x160/0B1120/1DD3B0?text=A" class="w-24 h-24 avatar-frame object-cover">
-                            <h2 class="text-2xl font-bold mt-4">Alex Morgan</h2>
-                            <p class="text-soft">alex.morgan@email.com</p>
-                        </div>
-                        <div class="glass-card p-4 divide-y divide-[var(--surface-border)]">
-                            <a href="#" class="profile-link py-3 flex justify-between items-center"><span>Edit Profile</span><span>></span></a>
-                            <a href="#" class="profile-link py-3 flex justify-between items-center" data-target="page-payments"><span>Payment Methods</span><span>></span></a>
-                            <a href="#" class="profile-link py-3 flex justify-between items-center"><span>Help & Support</span><span>></span></a>
-                        </div>
-                        <button class="btn btn-secondary w-full">Log Out</button>
-                    </div>
+                    <div class="space-y-6" id="profile-page-content"></div>
+                </section>
+
+                <!-- ===== PAGE: EDIT PROFILE ===== -->
+                <section class="page" id="page-edit-profile">
+                     <!-- Dynamic Content -->
+                </section>
+
+                <!-- ===== PAGE: HELP & SUPPORT ===== -->
+                <section class="page" id="page-help-support">
+                     <!-- Dynamic Content -->
                 </section>
 
                 <!-- ===== PAGE: WALKER PROFILE ===== -->


### PR DESCRIPTION
## Summary
- expand payment mock data to support multiple saved cards and render the list with safe formatting on the payments screen
- build an add-payment-method form with client-side validation, input helpers, and toast confirmation when a new card is saved
- add glassmorphism styling for saved payment cards to match the existing UI aesthetic

## Testing
- node --check assets/js/app.js

------
https://chatgpt.com/codex/tasks/task_e_68dc3a8f19cc832fa9872366320b3010