### PR TITLE
Simplify home dashboard quick links

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -531,6 +531,7 @@ body::after {
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
+    width: 100%;
     padding: 1rem 1.1rem;
     cursor: pointer;
     transition: var(--transition-base);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1826,11 +1826,6 @@ if (notificationsButton) {
     notificationsButton.addEventListener('click', () => showToast('You\'re all caught up!'));
 }
 
-const calendarLink = document.getElementById('home-calendar-link');
-if (calendarLink) {
-    calendarLink.addEventListener('click', () => goToPage('page-recurring-walks'));
-}
-
 const managePlansLink = document.getElementById('home-manage-plans');
 if (managePlansLink) {
     managePlansLink.addEventListener('click', () => goToPage('page-recurring-walks'));
@@ -1839,11 +1834,6 @@ if (managePlansLink) {
 const viewHistoryLink = document.getElementById('home-view-history');
 if (viewHistoryLink) {
     viewHistoryLink.addEventListener('click', () => goToPage('page-payments'));
-}
-
-const findWalkerLink = document.getElementById('cta-find-walker');
-if (findWalkerLink) {
-    findWalkerLink.addEventListener('click', () => launchBookingFlow('home-find-walker'));
 }
 
 // --- APP INITIALIZATION ---

--- a/index.html
+++ b/index.html
@@ -41,10 +41,6 @@
                         <div id="upcoming-walk-section" class="space-y-4">
                             <div class="home-section-header">
                                 <h2 class="section-title">Next Walk</h2>
-                                <button class="link-button" id="home-calendar-link" type="button">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4"/><path d="M8 2v4"/><path d="M3 10h18"/></svg>
-                                    <span>Open calendar</span>
-                                </button>
                             </div>
                             <article id="upcoming-walk-card" class="glass-card hero-card" data-walk-id="99">
                                 <div class="hero-card-main">
@@ -72,17 +68,6 @@
                         <div class="quick-actions-grid">
                             <button id="cta-book-walk" class="btn btn-primary w-full text-base py-4">Book New Walk</button>
                             <button id="cta-recurring-walk" class="btn btn-secondary w-full text-base py-4">Schedule Walk</button>
-                        </div>
-
-                        <div class="quick-link-row">
-                            <button class="quick-link-card" id="cta-find-walker" type="button">
-                                <span class="quick-link-icon">🧭</span>
-                                <div>
-                                    <p class="quick-link-title">Find nearby walkers</p>
-                                    <p class="quick-link-copy">See who is available this afternoon.</p>
-                                </div>
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>
-                            </button>
                         </div>
 
                         <section class="space-y-4">


### PR DESCRIPTION
## Summary
- remove the Next Walk calendar shortcut from the home hero
- drop the "Find nearby walkers" quick link card
- ensure recent activity cards stretch to the full content width

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc4f926ecc832f8db4b266a6c2ad25