### PR TITLE
Remove upcoming list and add walk history page

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,17 +72,6 @@
 
                         <section class="space-y-4">
                             <div class="home-section-header">
-                                <h2 class="section-title">Upcoming Walks</h2>
-                                <button class="link-button" id="home-manage-plans" type="button">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 1v22"/><path d="m17 5-5-4-5 4"/><path d="m7 19 5 4 5-4"/></svg>
-                                    <span>Manage plans</span>
-                                </button>
-                            </div>
-                            <div class="space-y-3" id="upcoming-walk-list"></div>
-                        </section>
-
-                        <section class="space-y-4">
-                            <div class="home-section-header">
                                 <h2 class="section-title">Recent Activity</h2>
                                 <button class="link-button" id="home-view-history" type="button">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 3h18v18H3z"/><path d="M16 3v18"/><path d="M8 3v18"/><path d="M3 8h18"/><path d="M3 16h18"/></svg>
@@ -155,9 +144,14 @@
                  <section class="page" id="page-recurring-walks">
                       <!-- Dynamic Content -->
                  </section>
-                 
+
                  <!-- ===== PAGE: PAYMENTS ===== -->
                  <section class="page" id="page-payments">
+                      <!-- Dynamic Content -->
+                 </section>
+
+                 <!-- ===== PAGE: WALK HISTORY ===== -->
+                 <section class="page" id="page-walk-history">
                       <!-- Dynamic Content -->
                  </section>
 


### PR DESCRIPTION
## Summary
- remove the secondary upcoming walks list from the home dashboard
- add a dedicated walk history page and hook up the "view all" control
- let history entries open their detailed summaries with a proper back path

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc525f6e58832fbae43a935f22c259